### PR TITLE
[#8] Warn on DBC signal name usage across multiple messages

### DIFF
--- a/dbcfeeder.py
+++ b/dbcfeeder.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 ########################################################################
-# Copyright (c) 2020,2023 Robert Bosch GmbH
+# Copyright (c) 2020,2023 Contributors to the Eclipse Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ Feeder parsing CAN data and sending to KUKSA.val
 """
 
 import argparse
+import asyncio
 import configparser
 import enum
 import errno
@@ -30,12 +31,14 @@ import logging
 import os
 import queue
 import sys
-import time
 import threading
-import asyncio
+import time
 
 from signal import SIGINT, SIGTERM, signal
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
+
+from cantools.database import Message
+from kuksa_client.grpc import EntryUpdate  # type: ignore
 
 from dbcfeederlib.canclient import CANClient
 from dbcfeederlib.canreader import CanReader
@@ -125,8 +128,9 @@ class Feeder:
     Start listening to the queue and transform CAN messages to VSS data and if conditions
     are fulfilled send them to the client wrapper which in turn send it to the bckend supported by the wrapper.
     """
+
     def __init__(self, kuksa_client: clientwrapper.ClientWrapper,
-                 elmcan_config: Dict[str, Any], dbc2val: bool = True, val2dbc: bool = False):
+                 elmcan_config: Dict[str, Any], dbc2vss: bool = True, vss2dbc: bool = False):
         self._running: bool = False
         self._reader: Optional[CanReader] = None
         self._mapper: Optional[dbc2vssmapper.Mapper] = None
@@ -135,8 +139,8 @@ class Feeder:
         self._kuksa_client = kuksa_client
         self._elmcan_config = elmcan_config
         self._disconnect_time = 0.0
-        self._dbc2val_enabled = dbc2val
-        self._val2dbc_enabled = val2dbc
+        self._dbc2vss_enabled = dbc2vss
+        self._vss2dbc_enabled = vss2dbc
         self._canclient: Optional[CANClient] = None
         self._transmit: bool = False
 
@@ -163,8 +167,11 @@ class Feeder:
         self._kuksa_client.start()
         threads = []
 
-        if self._dbc2val_enabled and self._mapper.has_dbc2vss_mapping():
-
+        if not self._dbc2vss_enabled:
+            log.info("Mapping of CAN signals to VSS Data Entries is disabled.")
+        elif not self._mapper.has_dbc2vss_mapping():
+            log.info("No mappings from CAN signals to VSS Data Entries defined.")
+        else:
             log.info("Setting up reception of CAN signals")
             if use_j1939:
                 log.info("Using J1939 reader")
@@ -185,25 +192,28 @@ class Feeder:
             receiver = threading.Thread(target=self._run_receiver)
             receiver.start()
             threads.append(receiver)
+
+        if not self._vss2dbc_enabled:
+            log.info("Mapping of VSS Data Entries to CAN signals is disabled.")
+        elif not self._mapper.has_vss2dbc_mapping():
+            log.info("No mappings from VSS Data Entries to CAN signals defined.")
+        elif not self._kuksa_client.supports_subscription():
+            log.error(
+                "The configured kuksa.val client [%s] does not support subscribing to VSS Data Entry changes!",
+                type(self._kuksa_client)
+            )
+            self.stop()
         else:
-            log.info("No dbc2val mappings found or dbc2val disabled!")
+            log.info("Starting thread for processing VSS Data Entry changes, writing to CAN device %s", canport)
+            # For now creating another bus
+            # Maybe support different buses for downstream/upstream in the future
 
-        if self._val2dbc_enabled and self._mapper.has_vss2dbc_mapping():
-            if not self._kuksa_client.supports_subscription():
-                log.error("Subscribing to VSS signals not supported by chosen client!")
-                self.stop()
-            else:
-                log.info("Starting transmit thread, using %s", canport)
-                # For now creating another bus
-                # Maybe support different buses for downstream/upstream in the future
+            self._canclient = CANClient(interface="socketcan", channel=canport, can_fd=can_fd)
 
-                self._canclient = CANClient(interface="socketcan", channel=canport, can_fd=can_fd)
+            transmitter = threading.Thread(target=self._run_transmitter)
+            transmitter.start()
+            threads.append(transmitter)
 
-                transmitter = threading.Thread(target=self._run_transmitter)
-                transmitter.start()
-                threads.append(transmitter)
-        else:
-            log.info("No val2dbc mappings found or val2dbc disabled!!")
         # Wait for all of them to finish
         for thread in threads:
             thread.join()
@@ -292,7 +302,10 @@ class Feeder:
                         messages_sent += 1
                         if messages_sent >= (2 * last_sent_log_entry):
                             log.info(
-                                "Number of VSS messages sent so far: %d, queue max size: %d",
+                                """
+                                Update datapoint requests sent to kuksa.val so far: %d,
+                                maximum number of queued CAN messages so far: %d
+                                """,
                                 messages_sent, queue_max_size
                             )
                             last_sent_log_entry = messages_sent
@@ -301,35 +314,42 @@ class Feeder:
             except Exception:
                 log.error("Exception caught in main loop", exc_info=True)
 
-    async def _vss_update(self, updates):
-        log.debug("vss-Update callback!")
-        dbc_ids = set()
-        for update in updates:
-            if update.entry.value is not None:
-                # This shall currently never happen as we do not subscribe to this
-                log.warning(
-                    "Current value for %s is now: %s of type %s",
-                    update.entry.path, update.entry.value.value, type(update.entry.value.value)
-                )
+    async def _vss_update(self, updates: List[EntryUpdate]):
+        if self._mapper is None:
+            # this should not happen because we always create a mapper
+            log.warning("Ignoring updated VSS Data Entries, no mapping information available")
+        elif self._canclient is None:
+            # this should not happen because we always create a CAN client
+            log.warning("Ignoring updated VSS Data Entries, no CAN bus client available")
+        else:
+            log.debug("Processing %d VSS Data Entry updates", len(updates))
+            dbc_signal_names: Set[str] = set()
+            for update in updates:
+                if update.entry.value is not None:
+                    # This should never happen as we do not subscribe to current value
+                    log.warning(
+                        "Current value for %s is now: %s of type %s",
+                        update.entry.path, update.entry.value.value, type(update.entry.value.value)
+                    )
 
-            if update.entry.actuator_target is not None:
+                if update.entry.actuator_target is not None:
+                    log.debug(
+                        "Target value for %s is now: %s of type %s",
+                        update.entry.path, update.entry.actuator_target, type(update.entry.actuator_target.value)
+                    )
+                    affected_signals = self._mapper.handle_update(update.entry.path, update.entry.actuator_target.value)
+                    dbc_signal_names.update(affected_signals)
+
+            messages_to_send: Set[Message] = set()
+            for signal_name in dbc_signal_names:
+                messages_to_send.update(self._mapper.get_messages_for_signal(signal_name))
+
+            for message_definition in messages_to_send:
                 log.debug(
-                    "Target value for %s is now: %s of type %s",
-                    update.entry.path, update.entry.actuator_target, type(update.entry.actuator_target.value)
+                    "sending CAN message %s with frame ID %#x",
+                    message_definition.name, message_definition.frame_id
                 )
-                new_dbc_ids = self._mapper.handle_update(update.entry.path, update.entry.actuator_target.value)
-                dbc_ids.update(new_dbc_ids)
-
-        can_ids = set()
-        for dbc_id in dbc_ids:
-            can_id = self._mapper.get_canid_for_signal(dbc_id)
-            can_ids.add(can_id)
-
-        for can_id in can_ids:
-            log.debug("CAN id to be sent, this is %#x", can_id)
-            sig_dict = self._mapper.get_value_dict(can_id)
-            message_definition = self._mapper.get_message_for_canid(can_id)
-            if message_definition is not None:
+                sig_dict = self._mapper.get_value_dict(message_definition.frame_id)
                 data = message_definition.encode(sig_dict)
                 self._canclient.send(arbitration_id=message_definition.frame_id, data=data)
 
@@ -596,7 +616,7 @@ def main(argv):
         elmcan_config = config[CONFIG_SECTION_ELMCAN]
 
     kuksa_val_client = _get_kuksa_val_client(args, config)
-    feeder = Feeder(kuksa_val_client, elmcan_config, dbc2val=use_dbc2val, val2dbc=use_val2dbc)
+    feeder = Feeder(kuksa_val_client, elmcan_config, dbc2vss=use_dbc2val, vss2dbc=use_val2dbc)
 
     def signal_handler(signal_received, *_):
         log.info("Received signal %s, stopping...", signal_received)
@@ -638,7 +658,7 @@ def parse_env_log(env_log, default=logging.INFO):
                 "critical",
             ]:
                 return specified_level.upper()
-            raise Exception(f"could not parse '{specified_level}' as a log level")
+            raise ValueError(f"could not parse '{specified_level}' as a log level")
         return default
 
     parsed_loglevels = {}
@@ -650,7 +670,7 @@ def parse_env_log(env_log, default=logging.INFO):
             if len(spec_parts) == 1:
                 # This is a root level spec
                 if "root" in parsed_loglevels:
-                    raise Exception("multiple root loglevels specified")
+                    raise ValueError("multiple root loglevels specified")
                 parsed_loglevels["root"] = parse_level(spec_parts[0])
             if len(spec_parts) == 2:
                 logger_name = spec_parts[0]

--- a/dbcfeederlib/databrokerclientwrapper.py
+++ b/dbcfeederlib/databrokerclientwrapper.py
@@ -201,11 +201,11 @@ class DatabrokerClientWrapper(clientwrapper.ClientWrapper):
 
     async def subscribe(self, vss_names: List[str], callback):
         """Create a subscription and invoke the callback when data received."""
-        entries = []
+        entries: List[SubscribeEntry] = []
         for name in vss_names:
             # Always subscribe to target
             subscribe_entry = SubscribeEntry(name, View.FIELDS, [Field.ACTUATOR_TARGET])
-            log.info(f"Subscribe entry: {subscribe_entry}")
+            log.info("Subscribe entry: %s", subscribe_entry)
             entries.append(subscribe_entry)
 
         # If there is a path VSSClient will request a secure connection

--- a/test/test_dbc/dbcparser_test.py
+++ b/test/test_dbc/dbcparser_test.py
@@ -18,8 +18,11 @@
 # SPDX-License-Identifier: Apache-2.0
 ########################################################################
 
-from dbcfeederlib import dbcparser
 import os
+
+import pytest  # type: ignore
+
+from dbcfeederlib import dbcparser
 
 NON_EXISTING_CAN_FRAME_ID: int = 0x45
 
@@ -33,10 +36,14 @@ def test_default_dbc():
     Verify that the parser can read message definitions from a standard .dbc file.
     """
     parser = dbcparser.DBCParser([def_dbc])
-    assert parser.get_canid_for_signal('SteeringAngle129') == 297
-    assert parser.get_canid_for_signal('DI_uiSpeed') == 599
+    msg_defs = parser.get_messages_for_signal('SteeringAngle129')
+    assert len(msg_defs) == 1
+    assert msg_defs.pop().frame_id == 297
+    msg_defs = parser.get_messages_for_signal('DI_uiSpeed')
+    assert len(msg_defs) == 1
+    assert msg_defs.pop().frame_id == 599
 
-    signals = parser.get_signals_for_canid(599)
+    signals = [signal.name for signal in parser.get_signals_by_frame_id(599)]
     assert "DI_speedChecksum" in signals
     assert "DI_speedCounter" in signals
     assert "DI_uiSpeed" in signals
@@ -50,10 +57,14 @@ def test_split_dbc():
     Verify that the parser can read message definitions from multiple standard .dbc files.
     """
     parser = dbcparser.DBCParser([test_path + "/test1_1.dbc", test_path + "/test1_2.dbc"])
+    msg_defs = parser.get_messages_for_signal('SteeringAngle129')
+    assert len(msg_defs) == 1
     # signal from message defined in first file
-    assert parser.get_canid_for_signal('SteeringAngle129') == 297
+    assert msg_defs.pop().frame_id == 297
+    msg_defs = parser.get_messages_for_signal('DI_uiSpeed')
+    assert len(msg_defs) == 1
     # signal from message defined in second file
-    assert parser.get_canid_for_signal('DI_uiSpeed') == 599
+    assert msg_defs.pop().frame_id == 599
 
 
 def test_duplicated_dbc():
@@ -62,8 +73,12 @@ def test_duplicated_dbc():
     specified several times.
     """
     parser = dbcparser.DBCParser([def_dbc, def_dbc])
-    assert parser.get_canid_for_signal('SteeringAngle129') == 297
-    assert parser.get_canid_for_signal('DI_uiSpeed') == 599
+    msg_defs = parser.get_messages_for_signal('SteeringAngle129')
+    assert len(msg_defs) == 1
+    assert msg_defs.pop().frame_id == 297
+    msg_defs = parser.get_messages_for_signal('DI_uiSpeed')
+    assert len(msg_defs) == 1
+    assert msg_defs.pop().frame_id == 599
 
 
 def test_single_kcd():
@@ -71,9 +86,11 @@ def test_single_kcd():
     Verify that the parser can read message definitions from a single .kcd file.
     """
     parser = dbcparser.DBCParser([test_path + "/test1_1.kcd"])
-    assert parser.get_canid_for_signal('DI_bmsRequestInterfaceVersion') == 0x16
+    msg_defs = parser.get_messages_for_signal('DI_bmsRequestInterfaceVersion')
+    assert len(msg_defs) == 1
+    assert msg_defs.pop().frame_id == 0x16
 
-    signals = parser.get_signals_for_canid(0x16)
+    signals = [signal.name for signal in parser.get_signals_by_frame_id(0x16)]
     assert "DI_bmsOpenContactorsRequest" in signals
     assert "DI_bmsRequestInterfaceVersion" in signals
 
@@ -83,10 +100,14 @@ def test_split_kcd():
     Verify that the parser can read message definitions from multiple .kcd files.
     """
     parser = dbcparser.DBCParser([test_path + "/test1_1.kcd", test_path + "/test1_2.kcd"])
+    msg_defs = parser.get_messages_for_signal('DI_bmsRequestInterfaceVersion')
+    assert len(msg_defs) == 1
     # signal from message defined in first file
-    assert parser.get_canid_for_signal('DI_bmsRequestInterfaceVersion') == 0x16
+    assert msg_defs.pop().frame_id == 0x16
+    msg_defs = parser.get_messages_for_signal('SteeringAngle129')
+    assert len(msg_defs) == 1
     # signal from message defined in second file
-    assert parser.get_canid_for_signal('SteeringAngle129') == 0x129
+    assert msg_defs.pop().frame_id == 0x129
 
 
 def test_mixed_file_types():
@@ -95,22 +116,50 @@ def test_mixed_file_types():
     standard .dbc files.
     """
     parser = dbcparser.DBCParser([test_path + "/test1_1.kcd", test_path + "/test1_2.dbc"])
+    msg_defs = parser.get_messages_for_signal('DI_bmsRequestInterfaceVersion')
+    assert len(msg_defs) == 1
     # signal from message defined in first file
-    assert parser.get_canid_for_signal('DI_bmsRequestInterfaceVersion') == 0x16
+    assert msg_defs.pop().frame_id == 0x16
+    msg_defs = parser.get_messages_for_signal('SteeringAngle129')
+    assert len(msg_defs) == 1
     # signal from message defined in second file
-    assert parser.get_canid_for_signal('SteeringAngle129') == 0x129
+    assert msg_defs.pop().frame_id == 0x129
 
 
-def test_get_message_for_for_non_existing_frame_id_returns_none():
+def test_get_message_by_non_existing_frame_id_raises_keyerror():
     parser = dbcparser.DBCParser([test_path + "/test1_1.kcd"])
-    assert parser.get_message_for_canid(NON_EXISTING_CAN_FRAME_ID) is None
+    with pytest.raises(KeyError):
+        parser.get_message_by_frame_id(NON_EXISTING_CAN_FRAME_ID)
 
 
-def test_get_signals_for_non_existing_frame_id_returns_empty_list():
+def test_get_signals_by_non_existing_frame_id_returns_empty_list():
     parser = dbcparser.DBCParser([test_path + "/test1_1.kcd"])
-    assert len(parser.get_signals_for_canid(NON_EXISTING_CAN_FRAME_ID)) == 0
+    assert len(parser.get_signals_by_frame_id(NON_EXISTING_CAN_FRAME_ID)) == 0
 
 
-def test_get_canid_for_unused_signal_name_returns_none():
+def test_get_messages_for_unused_signal_name_returns_empty_list():
     parser = dbcparser.DBCParser([test_path + "/test1_1.kcd"])
-    assert parser.get_canid_for_signal("unused_signal") is None
+    assert len(parser.get_messages_for_signal("unused_signal")) == 0
+
+
+def test_duplicate_signal_name_dbc():
+    # GIVEN a database with two messages defining a signal of name SignalOne
+    parser = dbcparser.DBCParser([test_path + "/duplicate_signal_name.kcd"])
+
+    # WHEN looing up the two messages by name
+    msg1 = parser._db.get_message_by_name('First')
+    msg2 = parser._db.get_message_by_name('Second')
+
+    # THEN they have different frame IDs
+    assert msg1.frame_id != msg2.frame_id
+
+    # AND they both have a signal of name SignalOne
+    assert msg1.get_signal_by_name('SignalOne') is not None
+    assert msg2.get_signal_by_name('SignalOne') is not None
+
+    # BUT WHEN looking up the CAN id for SignalOne
+    # THEN the IDs of both messages defining the signal are found
+    msg_list = parser.get_messages_for_signal('SignalOne')
+    assert len(msg_list) == 2
+    assert msg1 in msg_list
+    assert msg2 in msg_list

--- a/test/test_dbc/duplicate_signal_name.kcd
+++ b/test/test_dbc/duplicate_signal_name.kcd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<NetworkDefinition xmlns="http://kayak.2codeornot2code.org/1.0">
+    <Document name="duplicate signal name" date="Wed Jul 05 15:13:39 CEST 2023"></Document>
+    <Bus name="Private">
+        <Message id="0x16" name="First" length="1">
+            <Signal length="4" name="SignalOne" offset="0">
+                <Value max="14.0"/>
+            </Signal>
+            <Signal name="SignalTwo" offset="4">
+                <Value/>
+            </Signal>
+        </Message>
+        <Message id="0x1A" name="Second" length="1">
+            <Signal length="8" name="SignalOne" offset="0">
+                <Value max="196.0"/>
+            </Signal>
+        </Message>
+    </Bus>
+</NetworkDefinition>

--- a/test/test_mapping_error/mapping_for_ambiguous_signal.json
+++ b/test/test_mapping_error/mapping_for_ambiguous_signal.json
@@ -1,0 +1,17 @@
+{
+  "A": {
+    "children": {
+      "B": {
+        "datatype": "uint8",
+        "description": "...",
+        "type": "sensor",
+        "unit": "km",
+        "vss2dbc": {
+          "signal": "SignalOne"
+        }
+      }
+    },
+    "description": "Branch A.",
+    "type": "branch"
+  }
+}

--- a/test/test_mapping_error/mapping_for_unused_ambiguous_signal.json
+++ b/test/test_mapping_error/mapping_for_unused_ambiguous_signal.json
@@ -1,0 +1,17 @@
+{
+  "A": {
+    "children": {
+      "B": {
+        "datatype": "uint8",
+        "description": "...",
+        "type": "sensor",
+        "unit": "km",
+        "vss2dbc": {
+          "signal": "SignalTwo"
+        }
+      }
+    },
+    "description": "Branch A.",
+    "type": "branch"
+  }
+}

--- a/test/test_mapping_error/test_mapping_error.py
+++ b/test/test_mapping_error/test_mapping_error.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 ########################################################################
-# Copyright (c) 2023 Robert Bosch GmbH
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,17 +25,37 @@ import pytest  # type: ignore
 
 from dbcfeederlib import dbc2vssmapper
 
+test_path = os.path.dirname(os.path.abspath(__file__))
 
-def test_unknown_transform(caplog, capsys):
 
-    test_path = os.path.dirname(os.path.abspath(__file__))
+def test_unknown_transform(caplog: pytest.LogCaptureFixture):
+
     mapping_path = test_path + "/test_unknown_transform.json"
     dbc_file_names = [test_path + "/../../Model3CAN.dbc"]
 
     with pytest.raises(SystemExit) as excinfo:
         dbc2vssmapper.Mapper(mapping_path, dbc_file_names)
-    out, err = capsys.readouterr()
     assert excinfo.value.code == -1
-    assert caplog.record_tuples == [
-        ("dbcfeederlib.dbc2vssmapper", logging.ERROR, "Unsupported transformation definition for A.B")
-    ]
+    error_msg = ("dbcfeederlib.dbc2vssmapper", logging.ERROR, "Unsupported transformation definition for A.B")
+    assert error_msg in caplog.record_tuples
+
+
+def test_mapper_fails_for_duplicate_signal_definition():
+
+    mapping_path = test_path + "/mapping_for_ambiguous_signal.json"
+    dbc_file_names = [test_path + "/../test_dbc/duplicate_signal_name.kcd"]
+
+    with pytest.raises(SystemExit) as excinfo:
+        dbc2vssmapper.Mapper(mapping_path, dbc_file_names, fail_on_duplicate_signal_definitions=True)
+    assert excinfo.value.code == -1
+
+
+def test_mapper_ignores_unused_duplicate_signal_definition():
+
+    mapping_path = test_path + "/mapping_for_unused_ambiguous_signal.json"
+    dbc_file_names = [test_path + "/../test_dbc/duplicate_signal_name.kcd"]
+
+    mapper = dbc2vssmapper.Mapper(mapping_path, dbc_file_names, fail_on_duplicate_signal_definitions=True)
+    affected_signal_names = mapper.handle_update("A.B", 15)
+    assert len(affected_signal_names) == 1
+    assert "SignalTwo" in affected_signal_names

--- a/test/test_readers/test_readers.py
+++ b/test/test_readers/test_readers.py
@@ -56,7 +56,7 @@ class TestCanReader():
             ])
         message_def.decode = mock.Mock(return_value=decoded_message)  # type: ignore
         mapper = mock.create_autospec(spec=Mapper)
-        mapper.get_message_for_canid.return_value = message_def
+        mapper.get_message_by_frame_id.return_value = message_def
         mapper.get_dbc2vss_mappings.return_value = [VSSMapping(
             vss_name="Vehicle.Custom",
             dbc_name="UnboundedSignal",
@@ -92,7 +92,7 @@ class TestCanReader():
             ])
         message_def.decode = mock.Mock(return_value=decoded_message)  # type: ignore
         mapper = mock.create_autospec(spec=Mapper)
-        mapper.get_message_for_canid.return_value = message_def
+        mapper.get_message_by_frame_id.return_value = message_def
         queue = mock.create_autospec(spec=Queue)
         reader = TestCanReader.NoopCanReader(queue, mapper)
 
@@ -101,7 +101,7 @@ class TestCanReader():
         reader._process_can_message(0x103, bytes())
 
         # THEN the reader ignores the signal values
-        mapper.get_message_for_canid.assert_called_once_with(0x0103)
+        mapper.get_message_by_frame_id.assert_called_once_with(0x0103)
         mapper.get_dbc2vss_mappings.assert_not_called()
         queue.put.assert_not_called()
 
@@ -109,14 +109,14 @@ class TestCanReader():
         # GIVEN a reader based on an empty mapping definitions database
         queue = mock.create_autospec(spec=Queue)
         mapper = mock.create_autospec(spec=Mapper)
-        mapper.get_message_for_canid.return_value = None
+        mapper.get_message_by_frame_id.return_value = None
         reader = TestCanReader.NoopCanReader(queue, mapper)
 
         # WHEN a  message with an unknown PGN is received from the CAN bus
         reader._process_can_message(0x0102, bytes())
 
         # THEN the reader ignores the message
-        mapper.get_message_for_canid.assert_called_once_with(0x0102)
+        mapper.get_message_by_frame_id.assert_called_once_with(0x0102)
         queue.put.assert_not_called()
 
 
@@ -146,14 +146,14 @@ def get_dbc2vss_mappings(signal_name: str) -> List[VSSMapping]:
 def get_message_definition(frame_id: int, is_extended_frame: bool) -> Message:
     decoded_message = {"Signal_One": 0x10, "Signal_Two": 0x5432}
     msg_def = Message(
-            frame_id=frame_id,
-            name="Test_Message",
-            length=24,
-            is_extended_frame=is_extended_frame,
-            signals=[
-                Signal(name="Signal_One", start=0, length=8, maximum=213),
-                Signal(name="Signal_Two", start=8, length=16, is_signed=True),
-            ])
+        frame_id=frame_id,
+        name="Test_Message",
+        length=24,
+        is_extended_frame=is_extended_frame,
+        signals=[
+            Signal(name="Signal_One", start=0, length=8, maximum=213),
+            Signal(name="Signal_Two", start=8, length=16, is_signed=True),
+        ])
     msg_def.decode = mock.Mock(return_value=decoded_message)  # type: ignore
     return msg_def
 
@@ -173,7 +173,7 @@ class TestJ1939Reader():
         queue = mock.create_autospec(spec=Queue)
         message_def = get_message_definition(0x01FFFF10, True)
         mapper = mock.create_autospec(spec=Mapper)
-        mapper.get_message_for_canid.return_value = message_def
+        mapper.get_message_by_frame_id.return_value = message_def
         mapper.get_dbc2vss_mappings.side_effect = get_dbc2vss_mappings
         j1939reader = J1939Reader(queue, mapper, "vcan0")
 
@@ -197,7 +197,7 @@ class TestDBCReader():
         queue = mock.create_autospec(spec=Queue)
         message_def = get_message_definition(0x011A, False)
         mapper = mock.create_autospec(spec=Mapper)
-        mapper.get_message_for_canid.return_value = message_def
+        mapper.get_message_by_frame_id.return_value = message_def
         mapper.get_dbc2vss_mappings.side_effect = get_dbc2vss_mappings
         dbcreader = J1939Reader(queue, mapper, "vcan0")
 


### PR DESCRIPTION
During startup, the DBC Feeder reads in CAN message definitions
from arbitrary database files. When using the same signal name in
different message definitions, care needs to be taken that the semantics
of the signal are the same across all messages.