### PR TITLE
Use logging config from kuksa-python-sdk

### DIFF
--- a/.github/workflows/dash.yaml
+++ b/.github/workflows/dash.yaml
@@ -36,6 +36,7 @@ jobs:
           > dependencies.txt
 
       - name: Dash license check
-        uses: eclipse-kuksa/kuksa-actions/check-dash@2
+        uses: eclipse-kuksa/kuksa-actions/check-dash@4
         with:
           dashinput: ${{github.workspace}}/dependencies.txt
+          dashtoken: ${{ secrets.ECLIPSE_GITLAB_API_TOKEN}}

--- a/config/dbc_feeder.ini
+++ b/config/dbc_feeder.ini
@@ -53,9 +53,7 @@ tls = False
 # token=../kuksa-databroker/jwt/provide-all.token
 # The example below works if you have cloned kuksa-common in parallel to kuksa-can-provider
 # token=../kuksa-common/jwt/provide-all.token
-# For KUKSA.val Server the default behavior is to use the token provided as part of kuksa-client
-# So you only need to specify a different token if you want to use a different token
-# Possibly like below
+# For KUKSA.val Server you can specify token like below
 # token=../kuksa.val/kuksa_certificates/jwt/super-admin.json.token
 
 # Definitions on what directions to support.

--- a/dbcfeeder.py
+++ b/dbcfeeder.py
@@ -259,10 +259,8 @@ class Feeder:
                         messages_sent += 1
                         if messages_sent >= (2 * last_sent_log_entry):
                             log.info(
-                                """
-                                Update datapoint requests sent to kuksa.val so far: %d,
-                                maximum number of queued CAN messages so far: %d
-                                """,
+                                "Update datapoint requests sent to kuksa.val so far: %d, "
+                                "maximum number of queued CAN messages so far: %d",
                                 messages_sent, queue_max_size
                             )
                             last_sent_log_entry = messages_sent

--- a/dbcfeederlib/serverclientwrapper.py
+++ b/dbcfeederlib/serverclientwrapper.py
@@ -65,7 +65,7 @@ class ServerClientWrapper(clientwrapper.ClientWrapper):
 
         self._kuksa = KuksaClientThread(self._client_config)
         self._kuksa.start()
-        self._kuksa.authorize()
+        self._kuksa.authorize(token_or_tokenfile=self._token_path)
 
     def is_connected(self) -> bool:
         # This one is quite unreliable, see https://github.com/eclipse/kuksa.val/issues/523

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ cantools ~= 38.0
 pyyaml ~= 6.0
 can-j1939 ~= 2.0
 py_expression_eval ~= 0.3
-kuksa-client ~= 0.4.2
+kuksa-client ~= 0.4.3
 types-PyYAML ~= 6.0
 types-protobuf ~= 4.21
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ iniconfig==2.0.0
     # via pytest
 jsonpath-ng==1.6.1
     # via kuksa-client
-kuksa-client==0.4.2
+kuksa-client==0.4.3
     # via -r requirements.in
 msgpack==1.0.8
     # via python-can
@@ -50,7 +50,7 @@ protobuf==5.26.1
     # via grpcio-tools
 py-expression-eval==0.3.14
     # via -r requirements.in
-pygments==2.17.2
+pygments==2.18.0
     # via kuksa-client
 pyperclip==1.8.2
     # via cmd2


### PR DESCRIPTION
Uses logging config from `kuksa-python-sdk`.


* Requires an updated kuksa-client pypi package to work and changed dependency.
* Also adapts to that Kuksa Python SDK no longer contains default tokens for webserver, so we must specify them explicitly
* Also updates dash dependency
