### PR TITLE
Remove vss2dbc mapping for sensor

### DIFF
--- a/dbcfeederlib/dbc2vssmapper.py
+++ b/dbcfeederlib/dbc2vssmapper.py
@@ -426,7 +426,12 @@ class Mapper(DBCParser):
         if dbc2vss_def is not None:
             self._analyze_dbc2vss(expanded_name, node, dbc2vss_def)
         if "vss2dbc" in node:
-            self._analyze_vss2dbc(expanded_name, node, node["vss2dbc"])
+            if node["type"] == "actuator":
+                self._analyze_vss2dbc(expanded_name, node, node["vss2dbc"])
+            else:
+                # vss2dbc is handled by subscription to target value, so only makes sense for actuators
+                log.error("vss2dbc only allowed for actuators, VSS signal %s is not an actuator!", expanded_name)
+                sys.exit(-1)
 
     def _traverse_vss_node(self, name, node, prefix=""):
         """

--- a/mapping/README.md
+++ b/mapping/README.md
@@ -44,6 +44,8 @@ This is built on the assumption that the DBC provider always send target values 
 Having separate configurations (`dbc2vss` and `vss2dbc`) is needed as wanted value and actual value never are sent
 by the same DBC signal, they are not even part of the same CAN-frame.
 
+*This means that `vss2dbc` only can be used for actuators, as only actuators have target values!*
+
 ## Example mapping files
 
 Example mapping files for various VSS versions can be found in this folder.

--- a/mapping/vss_4.0/dbc_overlay.vspec
+++ b/mapping/vss_4.0/dbc_overlay.vspec
@@ -301,8 +301,6 @@ Vehicle.Powertrain.ElectricMotor.Temperature:
   dbc2vss:
     signal: PTC_rightTempIGBT
     interval_ms: 1000
-  vss2dbc:
-    signal: PTC_rightTempIGBT
 
 Vehicle.Cabin.Door.Row1.DriverSide.IsOpen:
   type: actuator

--- a/mapping/vss_4.0/vss_dbc.json
+++ b/mapping/vss_4.0/vss_dbc.json
@@ -7105,10 +7105,7 @@
                 },
                 "description": "Motor temperature.",
                 "type": "sensor",
-                "unit": "celsius",
-                "vss2dbc": {
-                  "signal": "PTC_rightTempIGBT"
-                }
+                "unit": "celsius"
               },
               "Torque": {
                 "datatype": "int16",

--- a/mapping/vss_4.1/dbc_overlay.vspec
+++ b/mapping/vss_4.1/dbc_overlay.vspec
@@ -301,8 +301,6 @@ Vehicle.Powertrain.ElectricMotor.Temperature:
   dbc2vss:
     signal: PTC_rightTempIGBT
     interval_ms: 1000
-  vss2dbc:
-    signal: PTC_rightTempIGBT
 
 Vehicle.Cabin.Door.Row1.DriverSide.IsOpen:
   type: actuator

--- a/mapping/vss_4.1/vss_dbc.json
+++ b/mapping/vss_4.1/vss_dbc.json
@@ -7476,10 +7476,7 @@
                 },
                 "description": "Motor temperature.",
                 "type": "sensor",
-                "unit": "celsius",
-                "vss2dbc": {
-                  "signal": "PTC_rightTempIGBT"
-                }
+                "unit": "celsius"
               },
               "Torque": {
                 "datatype": "int16",

--- a/test/test_mapping_error/mapping_for_ambiguous_signal.json
+++ b/test/test_mapping_error/mapping_for_ambiguous_signal.json
@@ -4,7 +4,7 @@
       "B": {
         "datatype": "uint8",
         "description": "...",
-        "type": "sensor",
+        "type": "actuator",
         "unit": "km",
         "vss2dbc": {
           "signal": "SignalOne"

--- a/test/test_mapping_error/mapping_vss2dbc_not_actuator.json
+++ b/test/test_mapping_error/mapping_vss2dbc_not_actuator.json
@@ -4,10 +4,10 @@
       "B": {
         "datatype": "uint8",
         "description": "...",
-        "type": "actuator",
+        "type": "sensor",
         "unit": "km",
         "vss2dbc": {
-          "signal": "SignalTwo"
+          "signal": "SignalOne"
         }
       }
     },

--- a/test/test_mapping_error/test_mapping_error.py
+++ b/test/test_mapping_error/test_mapping_error.py
@@ -40,6 +40,19 @@ def test_unknown_transform(caplog: pytest.LogCaptureFixture):
     assert error_msg in caplog.record_tuples
 
 
+def test_vss2dbc_sensor(caplog: pytest.LogCaptureFixture):
+
+    mapping_path = test_path + "/mapping_vss2dbc_not_actuator.json"
+    dbc_file_names = [test_path + "/../../Model3CAN.dbc"]
+
+    with pytest.raises(SystemExit) as excinfo:
+        dbc2vssmapper.Mapper(mapping_path, dbc_file_names)
+    assert excinfo.value.code == -1
+    error_msg = ("dbcfeederlib.dbc2vssmapper", logging.ERROR,
+                 "vss2dbc only allowed for actuators, VSS signal A.B is not an actuator!")
+    assert error_msg in caplog.record_tuples
+
+
 def test_mapper_fails_for_duplicate_signal_definition():
 
     mapping_path = test_path + "/mapping_for_ambiguous_signal.json"


### PR DESCRIPTION
Related to #23

Current CAN provider implementation always subscribe to target value for "vss2dbc". That does not really make sense for sensors, as they do not have target values. Remove it from example mapping and give a warning