### PR TITLE
Make container images also available on quay.io

### DIFF
--- a/.github/workflows/can-provider.yml
+++ b/.github/workflows/can-provider.yml
@@ -48,6 +48,7 @@ jobs:
         # list of Docker images to use as base name for tags
         images: |
           ghcr.io/eclipse-kuksa/kuksa-can-provider/can-provider
+          quay.io/eclipse-kuksa/can-provider
         # generate Docker tags based on the following events/attributes
         tags: |
           type=ref,event=branch
@@ -62,7 +63,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Log in to the Container registry
+    - name: Log in to ghcr.io container registry
       if: needs.check_ghcr_push.outputs.push == 'true'
       uses: docker/login-action@v3
       with:
@@ -70,7 +71,15 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build DBC provider container container and push to ghcr.io (and ttl.sh)
+    - name: Log in to quay.io container registry
+      if: needs.check_ghcr_push.outputs.push == 'true'
+      uses: docker/login-action@v3
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_IO_USERNAME }}
+        password: ${{ secrets.QUAY_IO_TOKEN }}
+
+    - name: Build DBC provider container container and push to ghcr.io, quay.io and ttl.sh
       id: ghcr-build
       if: needs.check_ghcr_push.outputs.push == 'true'
       uses: docker/build-push-action@v5

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # KUKSA CAN Provider
+
 ![KUKSA Logo](./doc/img/logo.png)
 
 This is a DBC CAN provider for the
@@ -49,35 +50,33 @@ Default values shall be provided by a JSON file, an example file exists in [dbc_
 
 *By default only dbc2val-mode is enabled!*
 
-
-
 ## General Setup Requirements
 
-1. Install can utils, e.g. in Ubuntu do:
+Install can utils, e.g. in Ubuntu do:
 
 ```console
-$ sudo apt update
-$ sudo apt install can-utils
+sudo apt update
+sudo apt install can-utils
 ```
 
-2. Check that at least Python version 3.9 is installed
+Check that at least Python version 3.9 is installed
 
 ```console
-$ python -V
+python -V
 ```
 
-3. Install the needed python packages
+Install the needed python packages
 
 ```console
-$ pip install -r requirements.txt
+pip install -r requirements.txt
 ```
 
 *Note - Sometimes DBC provider on main branch rely on a kuksa-client pre-release. Then you must add `--pre` to the command above!*
 
-4. If you want to run tests and linters, you will also need to install development dependencies
+If you want to run tests and linters, you will also need to install development dependencies
 
 ```console
-$ pip install -r requirements-dev.txt
+pip install -r requirements-dev.txt
 ```
 
 ## CAN Mapping
@@ -100,7 +99,6 @@ The KUKSA project publish the CAN provider as a Docker container.
 Please see [CAN Provider Docker Setup](doc/docker.md) for more information on how to build and use
 the CAN Provider as a Docker container.
 
-
 ## Provided can-dump  and DBC files
 
 CAN dump files are usable for test purposes. This repository contain two dump files which are used for testing and also used as basis for the examples in this repository.
@@ -110,7 +108,8 @@ is a CAN trace from  2018 Tesla M3 with software 2021.40.6.
 This data is interpreted using the [Model3CAN.dbc](./Model3CAN.dbc) [maintained by Josh Wardell](https://github.com/joshwardell/model3dbc).
 
 The canlog in the repo is compressed, to uncompress it (will be around 150MB) do
-```
+
+```console
 unxz candump-2021-12-08_151848.log.xz
 ```
 
@@ -123,6 +122,7 @@ A smaller excerpt from the above sample, with fewer signals.
 * [SAE-J1939 support](doc/j1939.md)
 
 ## Pre-commit set up
+
 This repository is set up to use [pre-commit](https://pre-commit.com/) hooks.
 Use `pip install pre-commit` to install pre-commit.
 After you clone the project, run `pre-commit install` to install pre-commit into your git hooks.

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -18,13 +18,13 @@ docker run  --net=host -e LOG_LEVEL=INFO can-provider:latest --server-type kuksa
 
 A pre-built Docker container is available in the repository. The container is availablat the github container registry via
 
-```
+```console
 docker pull ghcr.io/eclipse-kuksa/kuksa-can-provider/can-provider
 ```
 
-For users where the ghcr regsitry is not easily accesible, e.g. China mainland users, starting from release 0.4.4 we  also made the container images available at quay.io
+If the ghcr registry is not easily accessible to you, e.g. if you are a China mainland user, starting from release 0.4.4 we  also made the container images available at quay.io:
 
-```
+```console
 docker pull quay.io/eclipse-kuksa/can-provider
 ```
 
@@ -40,7 +40,6 @@ when starting the container. Below is an example based on that the token file
 [provide-all.token](https://github.com/eclipse/kuksa.val/blob/master/jwt/provide-all.token) is used and that `kuksa.val`
 is cloned to `/home/user/kuksa.val`. Then the token can be accessed by mounting the `jwt`folder using the `-v`
 and specify `token=/jwt/provide-all.token` in the [default configuration file](../config/dbc_feeder.ini).
-
 
 ```console
 docker run  --net=host -e LOG_LEVEL=INFO -v /home/user/kuksa.val/jwt:/jwt can-provider:latest

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -16,7 +16,17 @@ docker run  --net=host -e LOG_LEVEL=INFO can-provider:latest --server-type kuksa
 
 ## Pre-built Docker container
 
-A pre-built Docker container is available in the repository.
+A pre-built Docker container is available in the repository. The container is availablat the github container registry via
+
+```
+docker pull ghcr.io/eclipse-kuksa/kuksa-can-provider/can-provider
+```
+
+For users where the ghcr regsitry is not easily accesible, e.g. China mainland users, starting from release 0.4.4 we  also made the container images available at quay.io
+
+```
+docker pull quay.io/eclipse-kuksa/can-provider
+```
 
 ## KUKSA.val Server/Databroker Authentication when using Docker
 
@@ -37,4 +47,3 @@ docker run  --net=host -e LOG_LEVEL=INFO -v /home/user/kuksa.val/jwt:/jwt can-pr
 ```
 
 *Note that authentication in KUKSA Databroker by default is deactivated, and then no token needs to be given!*
-


### PR DESCRIPTION
Does for can-provider what. https://github.com/eclipse-kuksa/kuksa-databroker/issues/36 did for databroker

Only after merging we can verify this actually works.