### PR TITLE
Improve handling of NamedSignalValue

### DIFF
--- a/mapping/vss_4.2/dbc_overlay.vspec
+++ b/mapping/vss_4.2/dbc_overlay.vspec
@@ -1,0 +1,500 @@
+# This is a VSS example overlay that is to be used when generating vss_dbc.json in this repository
+# The content shall just be seen as examples that can be used for prototyping.
+# It does not in any way represent an official mapping.
+#
+# How to regenerate vss_dbc.json:
+#
+# 1. Decide which VSS version to use
+#
+# Two good places to check:
+# * See what versions KUKSA Databroker supports: https://github.com/eclipse/kuksa.val/tree/master/data/vss-core
+#   and https://github.com/eclipse/kuksa.val/tree/master/data/vss-core
+# * See what VSS releases that exists: https://github.com/COVESA/vehicle_signal_specification/releases
+#
+# (You can also also clone the VSS-repo and use whatever version you like)
+#
+# 2. Download Yaml file for selected version.
+#
+# Download VSS_*.yaml, units.yaml and quantities.yaml from  https://github.com/COVESA/vehicle_signal_specification/releases
+#
+# 3. Regenerate the json file
+#
+# vss-tools/vspec2json.py -e vss2dbc,dbc2vss,dbc -o dbc_overlay.vspec -u units.yaml --json-pretty vss_rel_4.0.yaml vss_dbc.json
+#
+# (For this you must typically have cloned https://github.com/COVESA/vss-tools or download vss-tools from pypi)
+#
+#
+# Type and datatype required, others will be inherited
+
+Vehicle.Chassis.SteeringWheel.Angle:
+  datatype: int16
+  type: sensor
+  dbc2vss:
+    signal: SteeringAngle129
+    interval_ms: 100
+    transform:
+      math: "floor(x+0.5)"
+
+Vehicle.Speed:
+  type: sensor
+  datatype: float
+  dbc2vss:
+    signal: DI_uiSpeed
+    interval_ms: 100
+
+Vehicle.OBD.Speed:
+  type: sensor
+  datatype: float
+  dbc2vss:
+    signal: DI_uiSpeed
+    interval_ms: 100
+
+Vehicle.Powertrain.Transmission.CurrentGear:
+  type: sensor
+  datatype: int8
+  dbc2vss:
+    interval_ms: 100
+    signal: DI_gear
+    transform:
+       mapping:
+        - from: DI_GEAR_D
+          to: 1
+        - from: DI_GEAR_P
+          to: 0
+        - from: DI_GEAR_INVALID
+          to: 0
+        - from: DI_GEAR_R
+          to: -1
+
+Vehicle.Powertrain.Transmission.IsParkLockEngaged:
+  type: sensor
+  datatype: boolean
+  dbc2vss:
+    interval_ms: 100
+    signal: DI_gear
+    transform:
+       mapping:
+        - from: DI_GEAR_D
+          to: false
+        - from: DI_GEAR_P
+          to: true
+        - from: DI_GEAR_INVALID
+          to: false
+        - from: DI_GEAR_R
+          to: false
+
+Vehicle.Powertrain.ElectricMotor.Torque:
+  type: sensor
+  datatype: int16
+  dbc2vss:
+    interval_ms: 100
+    signal: DIR_torqueActual
+
+Vehicle.OBD.ControlModuleVoltage:
+  type: sensor
+  datatype: float
+  dbc2vss:
+    interval_ms: 1000
+    signal: PCS_dcdcLvBusVolt
+
+Vehicle.Powertrain.TractionBattery.Charging.IsCharging:
+  type: sensor
+  datatype: boolean
+  dbc2vss:
+    interval_ms: 1000
+    signal: CP_hvChargeStatus
+    transform:
+       mapping:
+        - from: CP_CHARGE_CONNECTED
+          to: false
+        - from: CP_CHARGE_ENABLED
+          to: true
+        - from: CP_CHARGE_FAULTED
+          to: false
+        - from: CP_CHARGE_INACTIVE
+          to: false
+        - from: CP_CHARGE_STANDBY
+          to: false
+        - from: CP_EVSE_TEST_PASSED
+          to: true
+        - from: CP_EXT_EVSE_TEST_ACTIVE
+          to: true
+
+Vehicle.Chassis.Axle.Row1.Wheel.Left.Brake.IsFluidLevelLow:
+  type: sensor
+  datatype: boolean
+  dbc2vss:
+    interval_ms: 1000
+    signal: VCFRONT_brakeFluidLevel
+    transform:
+       mapping:
+        - from: LOW
+          to: true
+        - from: NORMAL
+          to: false
+
+Vehicle.Chassis.Axle.Row1.Wheel.Right.Brake.IsFluidLevelLow:
+  type: sensor
+  datatype: boolean
+  dbc2vss:
+    interval_ms: 1000
+    signal: VCFRONT_brakeFluidLevel
+    transform:
+       mapping:
+        - from: LOW
+          to: true
+        - from: NORMAL
+          to: false
+
+Vehicle.Chassis.Axle.Row2.Wheel.Left.Brake.IsFluidLevelLow:
+  type: sensor
+  datatype: boolean
+  dbc2vss:
+    interval_ms: 1000
+    signal: VCFRONT_brakeFluidLevel
+    transform:
+       mapping:
+        - from: LOW
+          to: true
+        - from: NORMAL
+          to: false
+
+Vehicle.Chassis.Axle.Row2.Wheel.Right.Brake.IsFluidLevelLow:
+  type: sensor
+  datatype: boolean
+  dbc2vss:
+    interval_ms: 1000
+    signal: VCFRONT_brakeFluidLevel
+    transform:
+       mapping:
+        - from: LOW
+          to: true
+        - from: NORMAL
+          to: false
+
+Vehicle.OBD.AmbientAirTemperature:
+  type: sensor
+  datatype: float
+  dbc2vss:
+    interval_ms: 1000
+    signal: VCFRONT_tempAmbientFiltered
+
+Vehicle.Body.Windshield.Front.WasherFluid.IsLevelLow:
+  type: sensor
+  datatype: boolean
+  dbc2vss:
+    interval_ms: 1000
+    signal: VCFRONT_washerFluidLevel
+    transform:
+       mapping:
+        - from: LOW
+          to: true
+        - from: NORMAL
+          to: false
+
+# VSS 4.0 changes to DriverSide/PassengerSide
+# We here assume that we have a LHD vehicle as
+# DBCFeeder cannot handle conditions
+# to use either driver or passenger side based on configuration
+Vehicle.Body.Mirrors.DriverSide.IsHeatingOn:
+  type: actuator
+  datatype: boolean
+  dbc2vss:
+    interval_ms: 1000
+    signal: VCLEFT_mirrorHeatState
+    transform:
+       mapping:
+        - from: HEATER_STATE_ON
+          to: true
+        - from: HEATER_STATE_OFF
+          to: false
+
+Vehicle.Body.Mirrors.PassengerSide.IsHeatingOn:
+  type: actuator
+  datatype: boolean
+  dbc2vss:
+    interval_ms: 1000
+    signal: VCLEFT_mirrorHeatState
+    transform:
+       mapping:
+        - from: HEATER_STATE_ON
+          to: true
+        - from: HEATER_STATE_OFF
+          to: false
+
+Vehicle.Body.Mirrors.DriverSide.Tilt:
+  datatype: int8
+  type: actuator
+  dbc2vss:
+    signal: VCLEFT_mirrorTiltYPosition
+    interval_ms: 100
+    transform:
+      math: "floor((x*40)-100)"
+  vss2dbc:
+    signal: VCLEFT_mirrorTiltYPosition
+    transform:
+      math: "(x+100)/40"
+
+Vehicle.Body.Mirrors.DriverSide.Pan:
+  datatype: int8
+  type: actuator
+  dbc2vss:
+    signal: VCLEFT_mirrorTiltXPosition
+    interval_ms: 100
+    transform:
+      math: "floor((x*40)-100)"
+  vss2dbc:
+    signal: VCLEFT_mirrorTiltXPosition
+    transform:
+      math: "(x+100)/40"
+
+Vehicle.Body.Mirrors.PassengerSide.Tilt:
+  datatype: int8
+  type: actuator
+  dbc2vss:
+    signal: VCRIGHT_mirrorTiltYPosition
+    interval_ms: 100
+    transform:
+      math: "floor((x*40)-100)"
+
+Vehicle.Body.Mirrors.PassengerSide.Pan:
+  datatype: int8
+  type: actuator
+  dbc2vss:
+    signal: VCRIGHT_mirrorTiltXPosition
+    interval_ms: 100
+    transform:
+      math: "floor((x*40)-100)"
+
+Vehicle.Body.Trunk.Rear.IsOpen:
+  type: actuator
+  datatype: boolean
+  dbc2vss:
+    interval_ms: 1000
+    signal: VCRIGHT_trunkLatchStatus
+    transform:
+       mapping:
+        - from: LATCH_AJAR
+          to: true
+        - from: LATCH_CLOSED
+          to: false
+        - from: LATCH_CLOSING
+          to: true
+        - from: LATCH_FAULT
+          to: true
+        - from: LATCH_OPENED
+          to: true
+        - from: LATCH_OPENING
+          to: true
+  vss2dbc:
+    signal: VCRIGHT_trunkLatchStatus
+    transform:
+       mapping:
+        - from: true
+          to: LATCH_OPENED
+        - from: false
+          to: LATCH_CLOSED
+
+Vehicle.Powertrain.ElectricMotor.Temperature:
+  datatype: int16
+  type: sensor
+  dbc2vss:
+    signal: PTC_rightTempIGBT
+    interval_ms: 1000
+
+Vehicle.Cabin.Door.Row1.DriverSide.IsOpen:
+  type: actuator
+  datatype: boolean
+  dbc2vss:
+    interval_ms: 500
+    signal: VCLEFT_frontDoorState
+    transform:
+       mapping:
+        - from: DOOR_STATE_CLOSED
+          to: false
+        - from: DOOR_STATE_OPEN_OR_AJAR
+          to: true
+        - from: DOOR_STATE_RELEASING_LATCH
+          to: true
+
+Vehicle.Cabin.Door.Row2.DriverSide.IsOpen:
+  type: actuator
+  datatype: boolean
+  dbc2vss:
+    interval_ms: 500
+    signal: VCLEFT_rearDoorState
+    transform:
+       mapping:
+        - from: DOOR_STATE_CLOSED
+          to: false
+        - from: DOOR_STATE_OPEN_OR_AJAR
+          to: true
+        - from: DOOR_STATE_RELEASING_LATCH
+          to: true
+
+Vehicle.Cabin.Seat.Row1.DriverSide.IsBelted:
+  type: sensor
+  datatype: boolean
+  dbc2vss:
+    interval_ms: 1000
+    signal: VCFRONT_driverBuckleStatus
+    transform:
+       mapping:
+        - from: BUCKLED
+          to: true
+        - from: UNBUCKLED
+          to: false
+
+Vehicle.Body.Lights.Brake.IsActive:
+  type: actuator
+  datatype: string
+  dbc2vss:
+    interval_ms: 100
+    signal: VCRIGHT_brakeLightStatus
+    transform:
+       mapping:
+        - from: LIGHT_OFF
+          to: 'INACTIVE'
+        - from: LIGHT_ON
+          to: 'ACTIVE'
+        - from: LIGHT_FAULT
+          to: 'INACTIVE'
+        - from: LIGHT_SNA
+          to: 'INACTIVE'
+
+Vehicle.Body.Lights.Fog.Rear.IsOn:
+  type: actuator
+  datatype: boolean
+  dbc2vss:
+    interval_ms: 100
+    signal: VCRIGHT_rearFogLightStatus
+    transform:
+       mapping:
+        - from: LIGHT_OFF
+          to: false
+        - from: LIGHT_ON
+          to: true
+        - from: LIGHT_FAULT
+          to: false
+        - from: LIGHT_SNA
+          to: false
+
+Vehicle.Body.Lights.Backup.IsOn:
+  type: actuator
+  datatype: boolean
+  dbc2vss:
+    interval_ms: 100
+    signal: VCRIGHT_reverseLightStatus
+    transform:
+       mapping:
+        - from: LIGHT_OFF
+          to: false
+        - from: LIGHT_ON
+          to: true
+        - from: LIGHT_FAULT
+          to: false
+        - from: LIGHT_SNA
+          to: false
+
+Vehicle.Body.Lights.DirectionIndicator.Right.IsSignaling:
+  type: actuator
+  datatype: boolean
+  dbc2vss:
+    interval_ms: 100
+    signal: VCRIGHT_turnSignalStatus
+    transform:
+       mapping:
+        - from: LIGHT_OFF
+          to: false
+        - from: LIGHT_ON
+          to: true
+        - from: LIGHT_FAULT
+          to: false
+        - from: LIGHT_SNA
+          to: false
+
+Vehicle.Body.Lights.DirectionIndicator.Left.IsSignaling:
+  type: actuator
+  datatype: boolean
+  dbc2vss:
+    interval_ms: 100
+    signal: VCLEFT_turnSignalStatus
+    transform:
+       mapping:
+        - from: LIGHT_OFF
+          to: false
+        - from: LIGHT_ON
+          to: true
+        - from: LIGHT_FAULT
+          to: false
+        - from: LIGHT_SNA
+          to: false
+
+Vehicle.Trailer.IsConnected:
+  type: sensor
+  datatype: boolean
+  dbc2vss:
+    interval_ms: 3000
+    signal: VCLEFT_trailerDetected
+    transform:
+       mapping:
+        - from: TRAILER_LIGHT_DETECTION_SNA
+          to: false
+        - from: TRAILER_LIGHT_DETECTION_DETECTED
+          to: true
+        - from: TRAILER_LIGHT_DETECTION_FAULT
+          to: false
+        - from: TRAILER_LIGHT_DETECTION_NOT_DETECTED
+          to: false
+
+Vehicle.OBD.EngineLoad:
+  type: sensor
+  datatype: float
+  dbc2vss:
+    signal: RearPower266
+    interval_ms: 100
+    transform:
+      math: "floor(abs(x/5))"
+
+# Explicit mapping for NamedSignalValue
+
+Vehicle.Cabin.Infotainment.HMI.SpeedUnit:
+  datatype: string
+  type: actuator
+  description: Customized speed unit - using string and implicit conversion
+  allowed: ['METERS_PER_SECOND', 'MILES_PER_HOUR', 'KILOMETERS_PER_HOUR']
+  dbc2vss:
+    signal: DI_uiSpeedUnits
+    interval_ms: 100
+    transform:
+      mapping:
+        - from: DI_SPEED_MPH
+          to: MILES_PER_HOUR
+        - from: DI_SPEED_KPH
+          to: KILOMETERS_PER_HOUR
+
+
+
+# Implicit mapping for NamedSignalValue
+# The mappings below does not make any practical sense
+# speed units have nothing to with media
+# They have just been selected so that we can test without modifying Databroker VSS json
+
+Vehicle.Cabin.Infotainment.Media.Played.Album:
+  datatype: string
+  type: sensor
+  description: Name of album being played
+  dbc2vss:
+    signal: DI_uiSpeedUnits
+    interval_ms: 100
+
+Vehicle.Cabin.Infotainment.Media.Volume:
+  datatype: uint8
+  type: actuator
+  min: 0
+  max: 100
+  unit: percent
+  description: Current Media Volume
+  dbc2vss:
+    signal: DI_uiSpeedUnits
+    interval_ms: 100

--- a/mapping/vss_4.2/vss_dbc.json
+++ b/mapping/vss_4.2/vss_dbc.json
@@ -1,0 +1,9746 @@
+{
+  "Vehicle": {
+    "children": {
+      "ADAS": {
+        "children": {
+          "ABS": {
+            "children": {
+              "IsEnabled": {
+                "datatype": "boolean",
+                "description": "Indicates if ABS is enabled. True = Enabled. False = Disabled.",
+                "type": "actuator"
+              },
+              "IsEngaged": {
+                "datatype": "boolean",
+                "description": "Indicates if ABS is currently regulating brake pressure. True = Engaged. False = Not Engaged.",
+                "type": "sensor"
+              },
+              "IsError": {
+                "datatype": "boolean",
+                "description": "Indicates if ABS incurred an error condition. True = Error. False = No Error.",
+                "type": "sensor"
+              }
+            },
+            "description": "Antilock Braking System signals.",
+            "type": "branch"
+          },
+          "ActiveAutonomyLevel": {
+            "allowed": [
+              "SAE_0",
+              "SAE_1",
+              "SAE_2_DISENGAGING",
+              "SAE_2",
+              "SAE_3_DISENGAGING",
+              "SAE_3",
+              "SAE_4_DISENGAGING",
+              "SAE_4",
+              "SAE_5"
+            ],
+            "comment": "Follows https://www.sae.org/news/2019/01/sae-updates-j3016-automated-driving-graphic taxonomy. For SAE levels 3 and 4 the system is required to alert the driver before it will disengage. Level 4 systems are required to reach a safe state even if a driver does not take over. Only level 5 systems are required to not rely on a driver at all. While level 2 systems require the driver to be monitoring the system at all times, many level 2 systems, often termed \"level 2.5\" systems, do warn the driver shortly before reaching their operational limits, therefore we also support the DISENGAGING state for SAE_2.",
+            "datatype": "string",
+            "description": "Indicates the currently active level of autonomy according to SAE J3016 taxonomy.",
+            "type": "sensor"
+          },
+          "CruiseControl": {
+            "children": {
+              "IsActive": {
+                "datatype": "boolean",
+                "description": "Indicates if cruise control system is active (i.e. actively controls speed). True = Active. False = Inactive.",
+                "type": "actuator"
+              },
+              "IsEnabled": {
+                "datatype": "boolean",
+                "description": "Indicates if cruise control system is enabled (e.g. ready to receive configurations and settings) True = Enabled. False = Disabled.",
+                "type": "actuator"
+              },
+              "IsError": {
+                "datatype": "boolean",
+                "description": "Indicates if cruise control system incurred an error condition. True = Error. False = No Error.",
+                "type": "sensor"
+              },
+              "SpeedSet": {
+                "datatype": "float",
+                "description": "Set cruise control speed in kilometers per hour.",
+                "type": "actuator",
+                "unit": "km/h"
+              }
+            },
+            "description": "Signals from Cruise Control system.",
+            "type": "branch"
+          },
+          "DMS": {
+            "children": {
+              "IsEnabled": {
+                "datatype": "boolean",
+                "description": "Indicates if DMS is enabled. True = Enabled. False = Disabled.",
+                "type": "actuator"
+              },
+              "IsError": {
+                "datatype": "boolean",
+                "description": "Indicates if DMS incurred an error condition. True = Error. False = No Error.",
+                "type": "sensor"
+              },
+              "IsWarning": {
+                "datatype": "boolean",
+                "description": "Indicates if DMS has registered a driver alert condition.",
+                "type": "sensor"
+              }
+            },
+            "description": "Driver Monitoring System signals.",
+            "type": "branch"
+          },
+          "EBA": {
+            "children": {
+              "IsEnabled": {
+                "datatype": "boolean",
+                "description": "Indicates if EBA is enabled. True = Enabled. False = Disabled.",
+                "type": "actuator"
+              },
+              "IsEngaged": {
+                "datatype": "boolean",
+                "description": "Indicates if EBA is currently regulating brake pressure. True = Engaged. False = Not Engaged.",
+                "type": "sensor"
+              },
+              "IsError": {
+                "datatype": "boolean",
+                "description": "Indicates if EBA incurred an error condition. True = Error. False = No Error.",
+                "type": "sensor"
+              }
+            },
+            "description": "Emergency Brake Assist (EBA) System signals.",
+            "type": "branch"
+          },
+          "EBD": {
+            "children": {
+              "IsEnabled": {
+                "datatype": "boolean",
+                "description": "Indicates if EBD is enabled. True = Enabled. False = Disabled.",
+                "type": "actuator"
+              },
+              "IsEngaged": {
+                "datatype": "boolean",
+                "description": "Indicates if EBD is currently regulating vehicle brakeforce distribution. True = Engaged. False = Not Engaged.",
+                "type": "sensor"
+              },
+              "IsError": {
+                "datatype": "boolean",
+                "description": "Indicates if EBD incurred an error condition. True = Error. False = No Error.",
+                "type": "sensor"
+              }
+            },
+            "description": "Electronic Brakeforce Distribution (EBD) System signals.",
+            "type": "branch"
+          },
+          "ESC": {
+            "children": {
+              "IsEnabled": {
+                "datatype": "boolean",
+                "description": "Indicates if ESC is enabled. True = Enabled. False = Disabled.",
+                "type": "actuator"
+              },
+              "IsEngaged": {
+                "datatype": "boolean",
+                "description": "Indicates if ESC is currently regulating vehicle stability. True = Engaged. False = Not Engaged.",
+                "type": "sensor"
+              },
+              "IsError": {
+                "datatype": "boolean",
+                "description": "Indicates if ESC incurred an error condition. True = Error. False = No Error.",
+                "type": "sensor"
+              },
+              "IsStrongCrossWindDetected": {
+                "datatype": "boolean",
+                "description": "Indicates if the ESC system is detecting strong cross winds. True = Strong cross winds detected. False = No strong cross winds detected.",
+                "type": "sensor"
+              },
+              "RoadFriction": {
+                "children": {
+                  "LowerBound": {
+                    "datatype": "float",
+                    "description": "Lower bound road friction, as calculated by the ESC system. 5% possibility that road friction is below this value. 0 = no friction, 100 = maximum friction.",
+                    "max": 100,
+                    "min": 0,
+                    "type": "sensor",
+                    "unit": "percent"
+                  },
+                  "MostProbable": {
+                    "datatype": "float",
+                    "description": "Most probable road friction, as calculated by the ESC system. Exact meaning of most probable is implementation specific. 0 = no friction, 100 = maximum friction.",
+                    "max": 100,
+                    "min": 0,
+                    "type": "sensor",
+                    "unit": "percent"
+                  },
+                  "UpperBound": {
+                    "datatype": "float",
+                    "description": "Upper bound road friction, as calculated by the ESC system. 95% possibility that road friction is below this value. 0 = no friction, 100 = maximum friction.",
+                    "max": 100,
+                    "min": 0,
+                    "type": "sensor",
+                    "unit": "percent"
+                  }
+                },
+                "description": "Road friction values reported by the ESC system.",
+                "type": "branch"
+              }
+            },
+            "description": "Electronic Stability Control System signals.",
+            "type": "branch"
+          },
+          "IsAutoPowerOptimize": {
+            "datatype": "boolean",
+            "description": "Auto Power Optimization Flag When set to 'true', the system enables automatic power optimization, dynamically adjusting the power optimization level based on runtime conditions or features managed by the OEM. When set to 'false', manual control of the power optimization level is allowed.",
+            "type": "actuator"
+          },
+          "LaneDepartureDetection": {
+            "children": {
+              "IsEnabled": {
+                "datatype": "boolean",
+                "description": "Indicates if lane departure detection system is enabled. True = Enabled. False = Disabled.",
+                "type": "actuator"
+              },
+              "IsError": {
+                "datatype": "boolean",
+                "description": "Indicates if lane departure system incurred an error condition. True = Error. False = No Error.",
+                "type": "sensor"
+              },
+              "IsWarning": {
+                "datatype": "boolean",
+                "description": "Indicates if lane departure detection registered a lane departure.",
+                "type": "sensor"
+              }
+            },
+            "description": "Signals from Lane Departure Detection System.",
+            "type": "branch"
+          },
+          "ObstacleDetection": {
+            "children": {
+              "IsEnabled": {
+                "datatype": "boolean",
+                "description": "Indicates if obstacle sensor system is enabled (i.e. monitoring for obstacles). True = Enabled. False = Disabled.",
+                "type": "actuator"
+              },
+              "IsError": {
+                "datatype": "boolean",
+                "description": "Indicates if obstacle sensor system incurred an error condition. True = Error. False = No Error.",
+                "type": "sensor"
+              },
+              "IsWarning": {
+                "datatype": "boolean",
+                "description": "Indicates if obstacle sensor system registered an obstacle.",
+                "type": "sensor"
+              }
+            },
+            "description": "Signals form Obstacle Sensor System.",
+            "type": "branch"
+          },
+          "PowerOptimizeLevel": {
+            "datatype": "uint8",
+            "description": "Power optimization level for this branch/subsystem. A higher number indicates more aggressive power optimization. Level 0 indicates that all functionality is enabled, no power optimization enabled. Level 10 indicates most aggressive power optimization mode, only essential functionality enabled.",
+            "max": 10,
+            "min": 0,
+            "type": "actuator"
+          },
+          "SupportedAutonomyLevel": {
+            "allowed": [
+              "SAE_0",
+              "SAE_1",
+              "SAE_2",
+              "SAE_3",
+              "SAE_4",
+              "SAE_5"
+            ],
+            "datatype": "string",
+            "description": "Indicates the highest level of autonomy according to SAE J3016 taxonomy the vehicle is capable of.",
+            "type": "attribute"
+          },
+          "TCS": {
+            "children": {
+              "IsEnabled": {
+                "datatype": "boolean",
+                "description": "Indicates if TCS is enabled. True = Enabled. False = Disabled.",
+                "type": "actuator"
+              },
+              "IsEngaged": {
+                "datatype": "boolean",
+                "description": "Indicates if TCS is currently regulating traction. True = Engaged. False = Not Engaged.",
+                "type": "sensor"
+              },
+              "IsError": {
+                "datatype": "boolean",
+                "description": "Indicates if TCS incurred an error condition. True = Error. False = No Error.",
+                "type": "sensor"
+              }
+            },
+            "description": "Traction Control System signals.",
+            "type": "branch"
+          }
+        },
+        "description": "All Advanced Driver Assist Systems data.",
+        "type": "branch"
+      },
+      "Acceleration": {
+        "children": {
+          "Lateral": {
+            "datatype": "float",
+            "description": "Vehicle acceleration in Y (lateral acceleration).",
+            "type": "sensor",
+            "unit": "m/s^2"
+          },
+          "Longitudinal": {
+            "datatype": "float",
+            "description": "Vehicle acceleration in X (longitudinal acceleration).",
+            "type": "sensor",
+            "unit": "m/s^2"
+          },
+          "Vertical": {
+            "datatype": "float",
+            "description": "Vehicle acceleration in Z (vertical acceleration).",
+            "type": "sensor",
+            "unit": "m/s^2"
+          }
+        },
+        "description": "Spatial acceleration. Axis definitions according to ISO 8855.",
+        "type": "branch"
+      },
+      "AngularVelocity": {
+        "children": {
+          "Pitch": {
+            "datatype": "float",
+            "description": "Vehicle rotation rate along Y (lateral).",
+            "type": "sensor",
+            "unit": "degrees/s"
+          },
+          "Roll": {
+            "datatype": "float",
+            "description": "Vehicle rotation rate along X (longitudinal).",
+            "type": "sensor",
+            "unit": "degrees/s"
+          },
+          "Yaw": {
+            "datatype": "float",
+            "description": "Vehicle rotation rate along Z (vertical).",
+            "type": "sensor",
+            "unit": "degrees/s"
+          }
+        },
+        "description": "Spatial rotation. Axis definitions according to ISO 8855.",
+        "type": "branch"
+      },
+      "AverageSpeed": {
+        "comment": "A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new trip is started. Calculation of average speed may exclude periods when the vehicle for example is not moving or transmission is in neutral.",
+        "datatype": "float",
+        "description": "Average speed for the current trip.",
+        "type": "sensor",
+        "unit": "km/h"
+      },
+      "Body": {
+        "children": {
+          "BodyType": {
+            "datatype": "string",
+            "description": "Body type code as defined by ISO 3779.",
+            "type": "attribute"
+          },
+          "Hood": {
+            "children": {
+              "IsOpen": {
+                "datatype": "boolean",
+                "description": "Is item open or closed? True = Fully or partially open. False = Fully closed.",
+                "type": "actuator"
+              },
+              "Position": {
+                "comment": "Relationship between Open/Close and Start/End position is item dependent.",
+                "datatype": "uint8",
+                "description": "Item position. 0 = Start position 100 = End position.",
+                "max": 100,
+                "min": 0,
+                "type": "actuator",
+                "unit": "percent"
+              },
+              "Switch": {
+                "allowed": [
+                  "INACTIVE",
+                  "CLOSE",
+                  "OPEN",
+                  "ONE_SHOT_CLOSE",
+                  "ONE_SHOT_OPEN"
+                ],
+                "datatype": "string",
+                "description": "Switch controlling sliding action such as window, sunroof, or blind.",
+                "type": "actuator"
+              }
+            },
+            "comment": "The hood is the hinged cover over the engine compartment of a motor vehicles. Depending on vehicle, it can be either in the front or back of the vehicle. Luggage compartments are in VSS called trunks, even if they are located at the front of the vehicle.",
+            "description": "Hood status. Start position for Hood is Closed.",
+            "type": "branch"
+          },
+          "Horn": {
+            "children": {
+              "IsActive": {
+                "datatype": "boolean",
+                "description": "Horn active or inactive. True = Active. False = Inactive.",
+                "type": "actuator"
+              }
+            },
+            "description": "Horn signals.",
+            "type": "branch"
+          },
+          "IsAutoPowerOptimize": {
+            "datatype": "boolean",
+            "description": "Auto Power Optimization Flag When set to 'true', the system enables automatic power optimization, dynamically adjusting the power optimization level based on runtime conditions or features managed by the OEM. When set to 'false', manual control of the power optimization level is allowed.",
+            "type": "actuator"
+          },
+          "Lights": {
+            "children": {
+              "Backup": {
+                "children": {
+                  "IsDefect": {
+                    "datatype": "boolean",
+                    "description": "Indicates if light is defect. True = Light is defect. False = Light has no defect.",
+                    "type": "sensor"
+                  },
+                  "IsOn": {
+                    "datatype": "boolean",
+                    "dbc2vss": {
+                      "interval_ms": 100,
+                      "signal": "VCRIGHT_reverseLightStatus",
+                      "transform": {
+                        "mapping": [
+                          {
+                            "from": "LIGHT_OFF",
+                            "to": false
+                          },
+                          {
+                            "from": "LIGHT_ON",
+                            "to": true
+                          },
+                          {
+                            "from": "LIGHT_FAULT",
+                            "to": false
+                          },
+                          {
+                            "from": "LIGHT_SNA",
+                            "to": false
+                          }
+                        ]
+                      }
+                    },
+                    "description": "Indicates if light is on or off. True = On. False = Off.",
+                    "type": "actuator"
+                  }
+                },
+                "description": "Backup lights.",
+                "type": "branch"
+              },
+              "Beam": {
+                "children": {
+                  "High": {
+                    "children": {
+                      "IsDefect": {
+                        "datatype": "boolean",
+                        "description": "Indicates if light is defect. True = Light is defect. False = Light has no defect.",
+                        "type": "sensor"
+                      },
+                      "IsOn": {
+                        "datatype": "boolean",
+                        "description": "Indicates if light is on or off. True = On. False = Off.",
+                        "type": "actuator"
+                      }
+                    },
+                    "description": "Beam lights.",
+                    "type": "branch"
+                  },
+                  "Low": {
+                    "children": {
+                      "IsDefect": {
+                        "datatype": "boolean",
+                        "description": "Indicates if light is defect. True = Light is defect. False = Light has no defect.",
+                        "type": "sensor"
+                      },
+                      "IsOn": {
+                        "datatype": "boolean",
+                        "description": "Indicates if light is on or off. True = On. False = Off.",
+                        "type": "actuator"
+                      }
+                    },
+                    "description": "Beam lights.",
+                    "type": "branch"
+                  }
+                },
+                "description": "Beam lights.",
+                "type": "branch"
+              },
+              "Brake": {
+                "children": {
+                  "IsActive": {
+                    "allowed": [
+                      "INACTIVE",
+                      "ACTIVE",
+                      "ADAPTIVE"
+                    ],
+                    "datatype": "string",
+                    "dbc2vss": {
+                      "interval_ms": 100,
+                      "signal": "VCRIGHT_brakeLightStatus",
+                      "transform": {
+                        "mapping": [
+                          {
+                            "from": "LIGHT_OFF",
+                            "to": "INACTIVE"
+                          },
+                          {
+                            "from": "LIGHT_ON",
+                            "to": "ACTIVE"
+                          },
+                          {
+                            "from": "LIGHT_FAULT",
+                            "to": "INACTIVE"
+                          },
+                          {
+                            "from": "LIGHT_SNA",
+                            "to": "INACTIVE"
+                          }
+                        ]
+                      }
+                    },
+                    "description": "Indicates if break-light is active. INACTIVE means lights are off. ACTIVE means lights are on. ADAPTIVE means that break-light is indicating emergency-breaking.",
+                    "type": "actuator"
+                  },
+                  "IsDefect": {
+                    "datatype": "boolean",
+                    "description": "Indicates if light is defect. True = Light is defect. False = Light has no defect.",
+                    "type": "sensor"
+                  }
+                },
+                "description": "Brake lights.",
+                "type": "branch"
+              },
+              "DirectionIndicator": {
+                "children": {
+                  "Left": {
+                    "children": {
+                      "IsDefect": {
+                        "datatype": "boolean",
+                        "description": "Indicates if light is defect. True = Light is defect. False = Light has no defect.",
+                        "type": "sensor"
+                      },
+                      "IsSignaling": {
+                        "datatype": "boolean",
+                        "dbc2vss": {
+                          "interval_ms": 100,
+                          "signal": "VCLEFT_turnSignalStatus",
+                          "transform": {
+                            "mapping": [
+                              {
+                                "from": "LIGHT_OFF",
+                                "to": false
+                              },
+                              {
+                                "from": "LIGHT_ON",
+                                "to": true
+                              },
+                              {
+                                "from": "LIGHT_FAULT",
+                                "to": false
+                              },
+                              {
+                                "from": "LIGHT_SNA",
+                                "to": false
+                              }
+                            ]
+                          }
+                        },
+                        "description": "Indicates if light is signaling or off. True = signaling. False = Off.",
+                        "type": "actuator"
+                      }
+                    },
+                    "description": "Indicator lights.",
+                    "type": "branch"
+                  },
+                  "Right": {
+                    "children": {
+                      "IsDefect": {
+                        "datatype": "boolean",
+                        "description": "Indicates if light is defect. True = Light is defect. False = Light has no defect.",
+                        "type": "sensor"
+                      },
+                      "IsSignaling": {
+                        "datatype": "boolean",
+                        "dbc2vss": {
+                          "interval_ms": 100,
+                          "signal": "VCRIGHT_turnSignalStatus",
+                          "transform": {
+                            "mapping": [
+                              {
+                                "from": "LIGHT_OFF",
+                                "to": false
+                              },
+                              {
+                                "from": "LIGHT_ON",
+                                "to": true
+                              },
+                              {
+                                "from": "LIGHT_FAULT",
+                                "to": false
+                              },
+                              {
+                                "from": "LIGHT_SNA",
+                                "to": false
+                              }
+                            ]
+                          }
+                        },
+                        "description": "Indicates if light is signaling or off. True = signaling. False = Off.",
+                        "type": "actuator"
+                      }
+                    },
+                    "description": "Indicator lights.",
+                    "type": "branch"
+                  }
+                },
+                "description": "Indicator lights.",
+                "type": "branch"
+              },
+              "Fog": {
+                "children": {
+                  "Front": {
+                    "children": {
+                      "IsDefect": {
+                        "datatype": "boolean",
+                        "description": "Indicates if light is defect. True = Light is defect. False = Light has no defect.",
+                        "type": "sensor"
+                      },
+                      "IsOn": {
+                        "datatype": "boolean",
+                        "description": "Indicates if light is on or off. True = On. False = Off.",
+                        "type": "actuator"
+                      }
+                    },
+                    "description": "Fog lights.",
+                    "type": "branch"
+                  },
+                  "Rear": {
+                    "children": {
+                      "IsDefect": {
+                        "datatype": "boolean",
+                        "description": "Indicates if light is defect. True = Light is defect. False = Light has no defect.",
+                        "type": "sensor"
+                      },
+                      "IsOn": {
+                        "datatype": "boolean",
+                        "dbc2vss": {
+                          "interval_ms": 100,
+                          "signal": "VCRIGHT_rearFogLightStatus",
+                          "transform": {
+                            "mapping": [
+                              {
+                                "from": "LIGHT_OFF",
+                                "to": false
+                              },
+                              {
+                                "from": "LIGHT_ON",
+                                "to": true
+                              },
+                              {
+                                "from": "LIGHT_FAULT",
+                                "to": false
+                              },
+                              {
+                                "from": "LIGHT_SNA",
+                                "to": false
+                              }
+                            ]
+                          }
+                        },
+                        "description": "Indicates if light is on or off. True = On. False = Off.",
+                        "type": "actuator"
+                      }
+                    },
+                    "description": "Fog lights.",
+                    "type": "branch"
+                  }
+                },
+                "description": "Fog lights.",
+                "type": "branch"
+              },
+              "Hazard": {
+                "children": {
+                  "IsDefect": {
+                    "datatype": "boolean",
+                    "description": "Indicates if light is defect. True = Light is defect. False = Light has no defect.",
+                    "type": "sensor"
+                  },
+                  "IsSignaling": {
+                    "datatype": "boolean",
+                    "description": "Indicates if light is signaling or off. True = signaling. False = Off.",
+                    "type": "actuator"
+                  }
+                },
+                "description": "Hazard lights.",
+                "type": "branch"
+              },
+              "IsHighBeamSwitchOn": {
+                "comment": "This signal indicates the status of the switch and does not indicate if low or high beam actually are on. That typically depends on vehicle logic and other signals like Lights.LightSwitch and Vehicle.LowVoltageSystemState.",
+                "datatype": "boolean",
+                "description": "Status of the high beam switch. True = high beam enabled. False = high beam not enabled.",
+                "type": "actuator"
+              },
+              "LicensePlate": {
+                "children": {
+                  "IsDefect": {
+                    "datatype": "boolean",
+                    "description": "Indicates if light is defect. True = Light is defect. False = Light has no defect.",
+                    "type": "sensor"
+                  },
+                  "IsOn": {
+                    "datatype": "boolean",
+                    "description": "Indicates if light is on or off. True = On. False = Off.",
+                    "type": "actuator"
+                  }
+                },
+                "description": "License plate lights.",
+                "type": "branch"
+              },
+              "LightSwitch": {
+                "allowed": [
+                  "OFF",
+                  "POSITION",
+                  "DAYTIME_RUNNING_LIGHTS",
+                  "AUTO",
+                  "BEAM"
+                ],
+                "comment": "A vehicle typically does not support all alternatives. Which lights that actually are lit may vary according to vehicle configuration and local legislation. OFF is typically indicated by 0. POSITION is typically indicated by ISO 7000 symbol 0456. DAYTIME_RUNNING_LIGHTS (DRL) can be indicated by ISO 7000 symbol 2611. AUTO indicates that vehicle automatically selects suitable lights. BEAM is typically indicated by ISO 7000 symbol 0083.",
+                "datatype": "string",
+                "description": "Status of the vehicle main light switch.",
+                "type": "actuator"
+              },
+              "Parking": {
+                "children": {
+                  "IsDefect": {
+                    "datatype": "boolean",
+                    "description": "Indicates if light is defect. True = Light is defect. False = Light has no defect.",
+                    "type": "sensor"
+                  },
+                  "IsOn": {
+                    "datatype": "boolean",
+                    "description": "Indicates if light is on or off. True = On. False = Off.",
+                    "type": "actuator"
+                  }
+                },
+                "description": "Parking lights.",
+                "type": "branch"
+              },
+              "Running": {
+                "children": {
+                  "IsDefect": {
+                    "datatype": "boolean",
+                    "description": "Indicates if light is defect. True = Light is defect. False = Light has no defect.",
+                    "type": "sensor"
+                  },
+                  "IsOn": {
+                    "datatype": "boolean",
+                    "description": "Indicates if light is on or off. True = On. False = Off.",
+                    "type": "actuator"
+                  }
+                },
+                "description": "Daytime running lights (DRL).",
+                "type": "branch"
+              }
+            },
+            "description": "Exterior lights.",
+            "type": "branch"
+          },
+          "Mirrors": {
+            "children": {
+              "DriverSide": {
+                "children": {
+                  "IsFolded": {
+                    "datatype": "boolean",
+                    "description": "Is mirror folded? True = Fully or partially folded. False = Fully unfolded.",
+                    "type": "actuator"
+                  },
+                  "IsHeatingOn": {
+                    "datatype": "boolean",
+                    "dbc2vss": {
+                      "interval_ms": 1000,
+                      "signal": "VCLEFT_mirrorHeatState",
+                      "transform": {
+                        "mapping": [
+                          {
+                            "from": "HEATER_STATE_ON",
+                            "to": true
+                          },
+                          {
+                            "from": "HEATER_STATE_OFF",
+                            "to": false
+                          }
+                        ]
+                      }
+                    },
+                    "description": "Mirror Heater on or off. True = Heater On. False = Heater Off.",
+                    "type": "actuator"
+                  },
+                  "IsLocked": {
+                    "datatype": "boolean",
+                    "description": "Is mirror movement locked? True = Locked, mirror will not react to Tilt/Pan change. False = Unlocked.",
+                    "type": "actuator"
+                  },
+                  "Pan": {
+                    "datatype": "int8",
+                    "dbc2vss": {
+                      "interval_ms": 100,
+                      "signal": "VCLEFT_mirrorTiltXPosition",
+                      "transform": {
+                        "math": "floor((x*40)-100)"
+                      }
+                    },
+                    "description": "Mirror pan as a percent. 0 = Center Position. 100 = Fully Left Position. -100 = Fully Right Position.",
+                    "max": 100,
+                    "min": -100,
+                    "type": "actuator",
+                    "unit": "percent",
+                    "vss2dbc": {
+                      "signal": "VCLEFT_mirrorTiltXPosition",
+                      "transform": {
+                        "math": "(x+100)/40"
+                      }
+                    }
+                  },
+                  "Tilt": {
+                    "datatype": "int8",
+                    "dbc2vss": {
+                      "interval_ms": 100,
+                      "signal": "VCLEFT_mirrorTiltYPosition",
+                      "transform": {
+                        "math": "floor((x*40)-100)"
+                      }
+                    },
+                    "description": "Mirror tilt as a percent. 0 = Center Position. 100 = Fully Upward Position. -100 = Fully Downward Position.",
+                    "max": 100,
+                    "min": -100,
+                    "type": "actuator",
+                    "unit": "percent",
+                    "vss2dbc": {
+                      "signal": "VCLEFT_mirrorTiltYPosition",
+                      "transform": {
+                        "math": "(x+100)/40"
+                      }
+                    }
+                  }
+                },
+                "description": "All mirrors.",
+                "type": "branch"
+              },
+              "PassengerSide": {
+                "children": {
+                  "IsFolded": {
+                    "datatype": "boolean",
+                    "description": "Is mirror folded? True = Fully or partially folded. False = Fully unfolded.",
+                    "type": "actuator"
+                  },
+                  "IsHeatingOn": {
+                    "datatype": "boolean",
+                    "dbc2vss": {
+                      "interval_ms": 1000,
+                      "signal": "VCLEFT_mirrorHeatState",
+                      "transform": {
+                        "mapping": [
+                          {
+                            "from": "HEATER_STATE_ON",
+                            "to": true
+                          },
+                          {
+                            "from": "HEATER_STATE_OFF",
+                            "to": false
+                          }
+                        ]
+                      }
+                    },
+                    "description": "Mirror Heater on or off. True = Heater On. False = Heater Off.",
+                    "type": "actuator"
+                  },
+                  "IsLocked": {
+                    "datatype": "boolean",
+                    "description": "Is mirror movement locked? True = Locked, mirror will not react to Tilt/Pan change. False = Unlocked.",
+                    "type": "actuator"
+                  },
+                  "Pan": {
+                    "datatype": "int8",
+                    "dbc2vss": {
+                      "interval_ms": 100,
+                      "signal": "VCRIGHT_mirrorTiltXPosition",
+                      "transform": {
+                        "math": "floor((x*40)-100)"
+                      }
+                    },
+                    "description": "Mirror pan as a percent. 0 = Center Position. 100 = Fully Left Position. -100 = Fully Right Position.",
+                    "max": 100,
+                    "min": -100,
+                    "type": "actuator",
+                    "unit": "percent"
+                  },
+                  "Tilt": {
+                    "datatype": "int8",
+                    "dbc2vss": {
+                      "interval_ms": 100,
+                      "signal": "VCRIGHT_mirrorTiltYPosition",
+                      "transform": {
+                        "math": "floor((x*40)-100)"
+                      }
+                    },
+                    "description": "Mirror tilt as a percent. 0 = Center Position. 100 = Fully Upward Position. -100 = Fully Downward Position.",
+                    "max": 100,
+                    "min": -100,
+                    "type": "actuator",
+                    "unit": "percent"
+                  }
+                },
+                "description": "All mirrors.",
+                "type": "branch"
+              }
+            },
+            "description": "All mirrors.",
+            "type": "branch"
+          },
+          "PowerOptimizeLevel": {
+            "datatype": "uint8",
+            "description": "Power optimization level for this branch/subsystem. A higher number indicates more aggressive power optimization. Level 0 indicates that all functionality is enabled, no power optimization enabled. Level 10 indicates most aggressive power optimization mode, only essential functionality enabled.",
+            "max": 10,
+            "min": 0,
+            "type": "actuator"
+          },
+          "Raindetection": {
+            "children": {
+              "Intensity": {
+                "datatype": "uint8",
+                "description": "Rain intensity. 0 = Dry, No Rain. 100 = Covered.",
+                "max": 100,
+                "type": "sensor",
+                "unit": "percent"
+              }
+            },
+            "description": "Rain sensor signals.",
+            "type": "branch"
+          },
+          "RearMainSpoilerPosition": {
+            "datatype": "float",
+            "description": "Rear spoiler position, 0% = Spoiler fully stowed. 100% = Spoiler fully exposed.",
+            "max": 100,
+            "min": 0,
+            "type": "actuator",
+            "unit": "percent"
+          },
+          "RefuelPosition": {
+            "allowed": [
+              "FRONT_LEFT",
+              "FRONT_RIGHT",
+              "MIDDLE_LEFT",
+              "MIDDLE_RIGHT",
+              "REAR_LEFT",
+              "REAR_RIGHT"
+            ],
+            "datatype": "string",
+            "deprecation": "v4.1 replaced with Vehicle.Powertrain.TractionBattery.Charging.ChargePortPosition and Vehicle.Powertrain.FuelSystem.RefuelPortPosition",
+            "description": "Location of the fuel cap or charge port.",
+            "type": "attribute"
+          },
+          "Trunk": {
+            "children": {
+              "Front": {
+                "children": {
+                  "IsLightOn": {
+                    "comment": "V4.0 Moved from Vehicle.Cabin.Lights.IsTrunkOn because Trunk is not defined as part of the Cabin.",
+                    "datatype": "boolean",
+                    "description": "Is trunk light on",
+                    "type": "actuator"
+                  },
+                  "IsLocked": {
+                    "datatype": "boolean",
+                    "description": "Is item locked or unlocked. True = Locked. False = Unlocked.",
+                    "type": "actuator"
+                  },
+                  "IsOpen": {
+                    "datatype": "boolean",
+                    "description": "Is item open or closed? True = Fully or partially open. False = Fully closed.",
+                    "type": "actuator"
+                  },
+                  "Position": {
+                    "comment": "Relationship between Open/Close and Start/End position is item dependent.",
+                    "datatype": "uint8",
+                    "description": "Item position. 0 = Start position 100 = End position.",
+                    "max": 100,
+                    "min": 0,
+                    "type": "actuator",
+                    "unit": "percent"
+                  },
+                  "Switch": {
+                    "allowed": [
+                      "INACTIVE",
+                      "CLOSE",
+                      "OPEN",
+                      "ONE_SHOT_CLOSE",
+                      "ONE_SHOT_OPEN"
+                    ],
+                    "datatype": "string",
+                    "description": "Switch controlling sliding action such as window, sunroof, or blind.",
+                    "type": "actuator"
+                  }
+                },
+                "comment": "A trunk is a luggage compartment in a vehicle. Depending on vehicle, it can be either in the front or back of the vehicle. Some vehicles may have trunks both at the front and at the rear of the vehicle.",
+                "description": "Trunk status. Start position for Trunk is Closed.",
+                "type": "branch"
+              },
+              "Rear": {
+                "children": {
+                  "IsLightOn": {
+                    "comment": "V4.0 Moved from Vehicle.Cabin.Lights.IsTrunkOn because Trunk is not defined as part of the Cabin.",
+                    "datatype": "boolean",
+                    "description": "Is trunk light on",
+                    "type": "actuator"
+                  },
+                  "IsLocked": {
+                    "datatype": "boolean",
+                    "description": "Is item locked or unlocked. True = Locked. False = Unlocked.",
+                    "type": "actuator"
+                  },
+                  "IsOpen": {
+                    "datatype": "boolean",
+                    "dbc2vss": {
+                      "interval_ms": 1000,
+                      "signal": "VCRIGHT_trunkLatchStatus",
+                      "transform": {
+                        "mapping": [
+                          {
+                            "from": "LATCH_AJAR",
+                            "to": true
+                          },
+                          {
+                            "from": "LATCH_CLOSED",
+                            "to": false
+                          },
+                          {
+                            "from": "LATCH_CLOSING",
+                            "to": true
+                          },
+                          {
+                            "from": "LATCH_FAULT",
+                            "to": true
+                          },
+                          {
+                            "from": "LATCH_OPENED",
+                            "to": true
+                          },
+                          {
+                            "from": "LATCH_OPENING",
+                            "to": true
+                          }
+                        ]
+                      }
+                    },
+                    "description": "Is item open or closed? True = Fully or partially open. False = Fully closed.",
+                    "type": "actuator",
+                    "vss2dbc": {
+                      "signal": "VCRIGHT_trunkLatchStatus",
+                      "transform": {
+                        "mapping": [
+                          {
+                            "from": true,
+                            "to": "LATCH_OPENED"
+                          },
+                          {
+                            "from": false,
+                            "to": "LATCH_CLOSED"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "Position": {
+                    "comment": "Relationship between Open/Close and Start/End position is item dependent.",
+                    "datatype": "uint8",
+                    "description": "Item position. 0 = Start position 100 = End position.",
+                    "max": 100,
+                    "min": 0,
+                    "type": "actuator",
+                    "unit": "percent"
+                  },
+                  "Switch": {
+                    "allowed": [
+                      "INACTIVE",
+                      "CLOSE",
+                      "OPEN",
+                      "ONE_SHOT_CLOSE",
+                      "ONE_SHOT_OPEN"
+                    ],
+                    "datatype": "string",
+                    "description": "Switch controlling sliding action such as window, sunroof, or blind.",
+                    "type": "actuator"
+                  }
+                },
+                "comment": "A trunk is a luggage compartment in a vehicle. Depending on vehicle, it can be either in the front or back of the vehicle. Some vehicles may have trunks both at the front and at the rear of the vehicle.",
+                "description": "Trunk status. Start position for Trunk is Closed.",
+                "type": "branch"
+              }
+            },
+            "comment": "A trunk is a luggage compartment in a vehicle. Depending on vehicle, it can be either in the front or back of the vehicle. Some vehicles may have trunks both at the front and at the rear of the vehicle.",
+            "description": "Trunk status. Start position for Trunk is Closed.",
+            "type": "branch"
+          },
+          "Windshield": {
+            "children": {
+              "Front": {
+                "children": {
+                  "IsHeatingOn": {
+                    "datatype": "boolean",
+                    "description": "Windshield heater status. False - off, True - on.",
+                    "type": "actuator"
+                  },
+                  "WasherFluid": {
+                    "children": {
+                      "IsLevelLow": {
+                        "datatype": "boolean",
+                        "dbc2vss": {
+                          "interval_ms": 1000,
+                          "signal": "VCFRONT_washerFluidLevel",
+                          "transform": {
+                            "mapping": [
+                              {
+                                "from": "LOW",
+                                "to": true
+                              },
+                              {
+                                "from": "NORMAL",
+                                "to": false
+                              }
+                            ]
+                          }
+                        },
+                        "description": "Low level indication for washer fluid. True = Level Low. False = Level OK.",
+                        "type": "sensor"
+                      },
+                      "Level": {
+                        "datatype": "uint8",
+                        "description": "Washer fluid level as a percent. 0 = Empty. 100 = Full.",
+                        "max": 100,
+                        "type": "sensor",
+                        "unit": "percent"
+                      }
+                    },
+                    "description": "Windshield washer fluid signals",
+                    "type": "branch"
+                  },
+                  "Wiping": {
+                    "children": {
+                      "Intensity": {
+                        "datatype": "uint8",
+                        "description": "Relative intensity/sensitivity for interval and rain sensor mode as requested by user/driver. Has no significance if Windshield.Wiping.Mode is OFF/SLOW/MEDIUM/FAST 0 - wipers inactive. 1 - minimum intensity (lowest frequency/sensitivity, longest interval). 2/3/4/... - higher intensity (higher frequency/sensitivity, shorter interval). Maximum value supported is vehicle specific.",
+                        "type": "actuator"
+                      },
+                      "IsWipersWorn": {
+                        "datatype": "boolean",
+                        "description": "Wiper wear status. True = Worn, Replacement recommended or required. False = Not Worn.",
+                        "type": "sensor"
+                      },
+                      "Mode": {
+                        "allowed": [
+                          "OFF",
+                          "SLOW",
+                          "MEDIUM",
+                          "FAST",
+                          "INTERVAL",
+                          "RAIN_SENSOR"
+                        ],
+                        "datatype": "string",
+                        "description": "Wiper mode requested by user/driver. INTERVAL indicates intermittent wiping, with fixed time interval between each wipe. RAIN_SENSOR indicates intermittent wiping based on rain intensity.",
+                        "type": "actuator"
+                      },
+                      "System": {
+                        "children": {
+                          "ActualPosition": {
+                            "comment": "Default parking position might be used as reference position.",
+                            "datatype": "float",
+                            "description": "Actual position of main wiper blade for the wiper system relative to reference position. Location of reference position (0 degrees) and direction of positive/negative degrees is vehicle specific.",
+                            "type": "actuator",
+                            "unit": "degrees"
+                          },
+                          "DriveCurrent": {
+                            "comment": "May be negative in special situations.",
+                            "datatype": "float",
+                            "description": "Actual current used by wiper drive.",
+                            "type": "sensor",
+                            "unit": "A"
+                          },
+                          "Frequency": {
+                            "comment": "Examples - 0 = Wipers stopped, 80 = Wipers doing 80 cycles per minute (in WIPE mode).",
+                            "datatype": "uint8",
+                            "description": "Wiping frequency/speed, measured in cycles per minute. The signal concerns the actual speed of the wiper blades when moving. Intervals/pauses are excluded, i.e. the value corresponds to the number of cycles that would be completed in 1 minute if wiping permanently over default range.",
+                            "type": "actuator",
+                            "unit": "cpm"
+                          },
+                          "IsBlocked": {
+                            "datatype": "boolean",
+                            "description": "Indicates if wiper movement is blocked. True = Movement blocked. False = Movement not blocked.",
+                            "type": "sensor"
+                          },
+                          "IsEndingWipeCycle": {
+                            "comment": "In continuous wiping between A and B this sensor can be used a trigger to update TargetPosition.",
+                            "datatype": "boolean",
+                            "description": "Indicates if current wipe movement is completed or near completion. True = Movement is completed or near completion. Changes to RequestedPosition will be executed first after reaching previous RequestedPosition, if it has not already been reached. False = Movement is not near completion. Any change to RequestedPosition will be executed immediately. Change of direction may not be allowed.",
+                            "type": "sensor"
+                          },
+                          "IsOverheated": {
+                            "datatype": "boolean",
+                            "description": "Indicates if wiper system is overheated. True = Wiper system overheated. False = Wiper system not overheated.",
+                            "type": "sensor"
+                          },
+                          "IsPositionReached": {
+                            "datatype": "boolean",
+                            "description": "Indicates if a requested position has been reached. IsPositionReached refers to the previous position in case the TargetPosition is updated while IsEndingWipeCycle=True. True = Current or Previous TargetPosition reached. False = Position not (yet) reached, or wipers have moved away from the reached position.",
+                            "type": "sensor"
+                          },
+                          "IsWiperError": {
+                            "datatype": "boolean",
+                            "description": "Indicates system failure. True if wiping is disabled due to system failure.",
+                            "type": "sensor"
+                          },
+                          "IsWiping": {
+                            "datatype": "boolean",
+                            "description": "Indicates wiper movement. True if wiper blades are moving. Change of direction shall be considered as IsWiping if wipers will continue to move directly after the change of direction.",
+                            "type": "sensor"
+                          },
+                          "Mode": {
+                            "allowed": [
+                              "STOP_HOLD",
+                              "WIPE",
+                              "PLANT_MODE",
+                              "EMERGENCY_STOP"
+                            ],
+                            "datatype": "string",
+                            "description": "Requested mode of wiper system. STOP_HOLD means that the wipers shall move to position given by TargetPosition and then hold the position. WIPE means that wipers shall move to the position given by TargetPosition and then hold the position if no new TargetPosition is requested. PLANT_MODE means that wiping is disabled. Exact behavior is vehicle specific. EMERGENCY_STOP means that wiping shall be immediately stopped without holding the position.",
+                            "type": "actuator"
+                          },
+                          "TargetPosition": {
+                            "comment": "Default parking position might be used as reference position.",
+                            "datatype": "float",
+                            "description": "Requested position of main wiper blade for the wiper system relative to reference position. Location of reference position (0 degrees) and direction of positive/negative degrees is vehicle specific. System behavior when receiving TargetPosition depends on Mode and IsEndingWipeCycle. Supported values are vehicle specific and might be dynamically corrected. If IsEndingWipeCycle=True then wipers will complete current movement before actuating new TargetPosition. If IsEndingWipeCycle=False then wipers will directly change destination if the TargetPosition is changed.",
+                            "type": "actuator",
+                            "unit": "degrees"
+                          }
+                        },
+                        "comment": "These signals are typically not directly available to the user/driver of the vehicle. The overlay in overlays/extensions/dual_wiper_systems.vspec can be used to modify this branch to support two instances; Primary and Secondary.",
+                        "description": "Signals to control behavior of wipers in detail. By default VSS expects only one instance.",
+                        "type": "branch"
+                      },
+                      "WiperWear": {
+                        "datatype": "uint8",
+                        "description": "Wiper wear as percent. 0 = No Wear. 100 = Worn. Replacement required. Method for calculating or estimating wiper wear is vehicle specific. For windshields with multiple wipers the wear reported shall correspond to the most worn wiper.",
+                        "max": 100,
+                        "type": "sensor",
+                        "unit": "percent"
+                      }
+                    },
+                    "description": "Windshield wiper signals.",
+                    "type": "branch"
+                  }
+                },
+                "description": "Windshield signals.",
+                "type": "branch"
+              },
+              "Rear": {
+                "children": {
+                  "IsHeatingOn": {
+                    "datatype": "boolean",
+                    "description": "Windshield heater status. False - off, True - on.",
+                    "type": "actuator"
+                  },
+                  "WasherFluid": {
+                    "children": {
+                      "IsLevelLow": {
+                        "datatype": "boolean",
+                        "description": "Low level indication for washer fluid. True = Level Low. False = Level OK.",
+                        "type": "sensor"
+                      },
+                      "Level": {
+                        "datatype": "uint8",
+                        "description": "Washer fluid level as a percent. 0 = Empty. 100 = Full.",
+                        "max": 100,
+                        "type": "sensor",
+                        "unit": "percent"
+                      }
+                    },
+                    "description": "Windshield washer fluid signals",
+                    "type": "branch"
+                  },
+                  "Wiping": {
+                    "children": {
+                      "Intensity": {
+                        "datatype": "uint8",
+                        "description": "Relative intensity/sensitivity for interval and rain sensor mode as requested by user/driver. Has no significance if Windshield.Wiping.Mode is OFF/SLOW/MEDIUM/FAST 0 - wipers inactive. 1 - minimum intensity (lowest frequency/sensitivity, longest interval). 2/3/4/... - higher intensity (higher frequency/sensitivity, shorter interval). Maximum value supported is vehicle specific.",
+                        "type": "actuator"
+                      },
+                      "IsWipersWorn": {
+                        "datatype": "boolean",
+                        "description": "Wiper wear status. True = Worn, Replacement recommended or required. False = Not Worn.",
+                        "type": "sensor"
+                      },
+                      "Mode": {
+                        "allowed": [
+                          "OFF",
+                          "SLOW",
+                          "MEDIUM",
+                          "FAST",
+                          "INTERVAL",
+                          "RAIN_SENSOR"
+                        ],
+                        "datatype": "string",
+                        "description": "Wiper mode requested by user/driver. INTERVAL indicates intermittent wiping, with fixed time interval between each wipe. RAIN_SENSOR indicates intermittent wiping based on rain intensity.",
+                        "type": "actuator"
+                      },
+                      "System": {
+                        "children": {
+                          "ActualPosition": {
+                            "comment": "Default parking position might be used as reference position.",
+                            "datatype": "float",
+                            "description": "Actual position of main wiper blade for the wiper system relative to reference position. Location of reference position (0 degrees) and direction of positive/negative degrees is vehicle specific.",
+                            "type": "actuator",
+                            "unit": "degrees"
+                          },
+                          "DriveCurrent": {
+                            "comment": "May be negative in special situations.",
+                            "datatype": "float",
+                            "description": "Actual current used by wiper drive.",
+                            "type": "sensor",
+                            "unit": "A"
+                          },
+                          "Frequency": {
+                            "comment": "Examples - 0 = Wipers stopped, 80 = Wipers doing 80 cycles per minute (in WIPE mode).",
+                            "datatype": "uint8",
+                            "description": "Wiping frequency/speed, measured in cycles per minute. The signal concerns the actual speed of the wiper blades when moving. Intervals/pauses are excluded, i.e. the value corresponds to the number of cycles that would be completed in 1 minute if wiping permanently over default range.",
+                            "type": "actuator",
+                            "unit": "cpm"
+                          },
+                          "IsBlocked": {
+                            "datatype": "boolean",
+                            "description": "Indicates if wiper movement is blocked. True = Movement blocked. False = Movement not blocked.",
+                            "type": "sensor"
+                          },
+                          "IsEndingWipeCycle": {
+                            "comment": "In continuous wiping between A and B this sensor can be used a trigger to update TargetPosition.",
+                            "datatype": "boolean",
+                            "description": "Indicates if current wipe movement is completed or near completion. True = Movement is completed or near completion. Changes to RequestedPosition will be executed first after reaching previous RequestedPosition, if it has not already been reached. False = Movement is not near completion. Any change to RequestedPosition will be executed immediately. Change of direction may not be allowed.",
+                            "type": "sensor"
+                          },
+                          "IsOverheated": {
+                            "datatype": "boolean",
+                            "description": "Indicates if wiper system is overheated. True = Wiper system overheated. False = Wiper system not overheated.",
+                            "type": "sensor"
+                          },
+                          "IsPositionReached": {
+                            "datatype": "boolean",
+                            "description": "Indicates if a requested position has been reached. IsPositionReached refers to the previous position in case the TargetPosition is updated while IsEndingWipeCycle=True. True = Current or Previous TargetPosition reached. False = Position not (yet) reached, or wipers have moved away from the reached position.",
+                            "type": "sensor"
+                          },
+                          "IsWiperError": {
+                            "datatype": "boolean",
+                            "description": "Indicates system failure. True if wiping is disabled due to system failure.",
+                            "type": "sensor"
+                          },
+                          "IsWiping": {
+                            "datatype": "boolean",
+                            "description": "Indicates wiper movement. True if wiper blades are moving. Change of direction shall be considered as IsWiping if wipers will continue to move directly after the change of direction.",
+                            "type": "sensor"
+                          },
+                          "Mode": {
+                            "allowed": [
+                              "STOP_HOLD",
+                              "WIPE",
+                              "PLANT_MODE",
+                              "EMERGENCY_STOP"
+                            ],
+                            "datatype": "string",
+                            "description": "Requested mode of wiper system. STOP_HOLD means that the wipers shall move to position given by TargetPosition and then hold the position. WIPE means that wipers shall move to the position given by TargetPosition and then hold the position if no new TargetPosition is requested. PLANT_MODE means that wiping is disabled. Exact behavior is vehicle specific. EMERGENCY_STOP means that wiping shall be immediately stopped without holding the position.",
+                            "type": "actuator"
+                          },
+                          "TargetPosition": {
+                            "comment": "Default parking position might be used as reference position.",
+                            "datatype": "float",
+                            "description": "Requested position of main wiper blade for the wiper system relative to reference position. Location of reference position (0 degrees) and direction of positive/negative degrees is vehicle specific. System behavior when receiving TargetPosition depends on Mode and IsEndingWipeCycle. Supported values are vehicle specific and might be dynamically corrected. If IsEndingWipeCycle=True then wipers will complete current movement before actuating new TargetPosition. If IsEndingWipeCycle=False then wipers will directly change destination if the TargetPosition is changed.",
+                            "type": "actuator",
+                            "unit": "degrees"
+                          }
+                        },
+                        "comment": "These signals are typically not directly available to the user/driver of the vehicle. The overlay in overlays/extensions/dual_wiper_systems.vspec can be used to modify this branch to support two instances; Primary and Secondary.",
+                        "description": "Signals to control behavior of wipers in detail. By default VSS expects only one instance.",
+                        "type": "branch"
+                      },
+                      "WiperWear": {
+                        "datatype": "uint8",
+                        "description": "Wiper wear as percent. 0 = No Wear. 100 = Worn. Replacement required. Method for calculating or estimating wiper wear is vehicle specific. For windshields with multiple wipers the wear reported shall correspond to the most worn wiper.",
+                        "max": 100,
+                        "type": "sensor",
+                        "unit": "percent"
+                      }
+                    },
+                    "description": "Windshield wiper signals.",
+                    "type": "branch"
+                  }
+                },
+                "description": "Windshield signals.",
+                "type": "branch"
+              }
+            },
+            "description": "Windshield signals.",
+            "type": "branch"
+          }
+        },
+        "description": "All body components.",
+        "type": "branch"
+      },
+      "Cabin": {
+        "children": {
+          "Convertible": {
+            "children": {
+              "Status": {
+                "allowed": [
+                  "UNDEFINED",
+                  "CLOSED",
+                  "OPEN",
+                  "CLOSING",
+                  "OPENING",
+                  "STALLED"
+                ],
+                "datatype": "string",
+                "description": "Roof status on convertible vehicles.",
+                "type": "sensor"
+              }
+            },
+            "description": "Convertible roof.",
+            "type": "branch"
+          },
+          "Door": {
+            "children": {
+              "Row1": {
+                "children": {
+                  "DriverSide": {
+                    "children": {
+                      "IsChildLockActive": {
+                        "datatype": "boolean",
+                        "description": "Is door child lock active. True = Door cannot be opened from inside. False = Door can be opened from inside.",
+                        "type": "sensor"
+                      },
+                      "IsLocked": {
+                        "datatype": "boolean",
+                        "description": "Is item locked or unlocked. True = Locked. False = Unlocked.",
+                        "type": "actuator"
+                      },
+                      "IsOpen": {
+                        "datatype": "boolean",
+                        "dbc2vss": {
+                          "interval_ms": 500,
+                          "signal": "VCLEFT_frontDoorState",
+                          "transform": {
+                            "mapping": [
+                              {
+                                "from": "DOOR_STATE_CLOSED",
+                                "to": false
+                              },
+                              {
+                                "from": "DOOR_STATE_OPEN_OR_AJAR",
+                                "to": true
+                              },
+                              {
+                                "from": "DOOR_STATE_RELEASING_LATCH",
+                                "to": true
+                              }
+                            ]
+                          }
+                        },
+                        "description": "Is item open or closed? True = Fully or partially open. False = Fully closed.",
+                        "type": "actuator"
+                      },
+                      "Position": {
+                        "comment": "Relationship between Open/Close and Start/End position is item dependent.",
+                        "datatype": "uint8",
+                        "description": "Item position. 0 = Start position 100 = End position.",
+                        "max": 100,
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "Shade": {
+                        "children": {
+                          "IsOpen": {
+                            "datatype": "boolean",
+                            "description": "Is item open or closed? True = Fully or partially open. False = Fully closed.",
+                            "type": "actuator"
+                          },
+                          "Position": {
+                            "comment": "Relationship between Open/Close and Start/End position is item dependent.",
+                            "datatype": "uint8",
+                            "description": "Item position. 0 = Start position 100 = End position.",
+                            "max": 100,
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "Switch": {
+                            "allowed": [
+                              "INACTIVE",
+                              "CLOSE",
+                              "OPEN",
+                              "ONE_SHOT_CLOSE",
+                              "ONE_SHOT_OPEN"
+                            ],
+                            "datatype": "string",
+                            "description": "Switch controlling sliding action such as window, sunroof, or blind.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Side window shade. Open = Retracted, Closed = Deployed. Start position for Shade is Open/Retracted.",
+                        "type": "branch"
+                      },
+                      "Switch": {
+                        "allowed": [
+                          "INACTIVE",
+                          "CLOSE",
+                          "OPEN",
+                          "ONE_SHOT_CLOSE",
+                          "ONE_SHOT_OPEN"
+                        ],
+                        "datatype": "string",
+                        "description": "Switch controlling sliding action such as window, sunroof, or blind.",
+                        "type": "actuator"
+                      },
+                      "Window": {
+                        "children": {
+                          "IsOpen": {
+                            "datatype": "boolean",
+                            "description": "Is item open or closed? True = Fully or partially open. False = Fully closed.",
+                            "type": "actuator"
+                          },
+                          "Position": {
+                            "comment": "Relationship between Open/Close and Start/End position is item dependent.",
+                            "datatype": "uint8",
+                            "description": "Item position. 0 = Start position 100 = End position.",
+                            "max": 100,
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "Switch": {
+                            "allowed": [
+                              "INACTIVE",
+                              "CLOSE",
+                              "OPEN",
+                              "ONE_SHOT_CLOSE",
+                              "ONE_SHOT_OPEN"
+                            ],
+                            "datatype": "string",
+                            "description": "Switch controlling sliding action such as window, sunroof, or blind.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Door window status. Start position for Window is Closed.",
+                        "type": "branch"
+                      }
+                    },
+                    "description": "All doors, including windows and switches.",
+                    "type": "branch"
+                  },
+                  "PassengerSide": {
+                    "children": {
+                      "IsChildLockActive": {
+                        "datatype": "boolean",
+                        "description": "Is door child lock active. True = Door cannot be opened from inside. False = Door can be opened from inside.",
+                        "type": "sensor"
+                      },
+                      "IsLocked": {
+                        "datatype": "boolean",
+                        "description": "Is item locked or unlocked. True = Locked. False = Unlocked.",
+                        "type": "actuator"
+                      },
+                      "IsOpen": {
+                        "datatype": "boolean",
+                        "description": "Is item open or closed? True = Fully or partially open. False = Fully closed.",
+                        "type": "actuator"
+                      },
+                      "Position": {
+                        "comment": "Relationship between Open/Close and Start/End position is item dependent.",
+                        "datatype": "uint8",
+                        "description": "Item position. 0 = Start position 100 = End position.",
+                        "max": 100,
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "Shade": {
+                        "children": {
+                          "IsOpen": {
+                            "datatype": "boolean",
+                            "description": "Is item open or closed? True = Fully or partially open. False = Fully closed.",
+                            "type": "actuator"
+                          },
+                          "Position": {
+                            "comment": "Relationship between Open/Close and Start/End position is item dependent.",
+                            "datatype": "uint8",
+                            "description": "Item position. 0 = Start position 100 = End position.",
+                            "max": 100,
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "Switch": {
+                            "allowed": [
+                              "INACTIVE",
+                              "CLOSE",
+                              "OPEN",
+                              "ONE_SHOT_CLOSE",
+                              "ONE_SHOT_OPEN"
+                            ],
+                            "datatype": "string",
+                            "description": "Switch controlling sliding action such as window, sunroof, or blind.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Side window shade. Open = Retracted, Closed = Deployed. Start position for Shade is Open/Retracted.",
+                        "type": "branch"
+                      },
+                      "Switch": {
+                        "allowed": [
+                          "INACTIVE",
+                          "CLOSE",
+                          "OPEN",
+                          "ONE_SHOT_CLOSE",
+                          "ONE_SHOT_OPEN"
+                        ],
+                        "datatype": "string",
+                        "description": "Switch controlling sliding action such as window, sunroof, or blind.",
+                        "type": "actuator"
+                      },
+                      "Window": {
+                        "children": {
+                          "IsOpen": {
+                            "datatype": "boolean",
+                            "description": "Is item open or closed? True = Fully or partially open. False = Fully closed.",
+                            "type": "actuator"
+                          },
+                          "Position": {
+                            "comment": "Relationship between Open/Close and Start/End position is item dependent.",
+                            "datatype": "uint8",
+                            "description": "Item position. 0 = Start position 100 = End position.",
+                            "max": 100,
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "Switch": {
+                            "allowed": [
+                              "INACTIVE",
+                              "CLOSE",
+                              "OPEN",
+                              "ONE_SHOT_CLOSE",
+                              "ONE_SHOT_OPEN"
+                            ],
+                            "datatype": "string",
+                            "description": "Switch controlling sliding action such as window, sunroof, or blind.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Door window status. Start position for Window is Closed.",
+                        "type": "branch"
+                      }
+                    },
+                    "description": "All doors, including windows and switches.",
+                    "type": "branch"
+                  }
+                },
+                "description": "All doors, including windows and switches.",
+                "type": "branch"
+              },
+              "Row2": {
+                "children": {
+                  "DriverSide": {
+                    "children": {
+                      "IsChildLockActive": {
+                        "datatype": "boolean",
+                        "description": "Is door child lock active. True = Door cannot be opened from inside. False = Door can be opened from inside.",
+                        "type": "sensor"
+                      },
+                      "IsLocked": {
+                        "datatype": "boolean",
+                        "description": "Is item locked or unlocked. True = Locked. False = Unlocked.",
+                        "type": "actuator"
+                      },
+                      "IsOpen": {
+                        "datatype": "boolean",
+                        "dbc2vss": {
+                          "interval_ms": 500,
+                          "signal": "VCLEFT_rearDoorState",
+                          "transform": {
+                            "mapping": [
+                              {
+                                "from": "DOOR_STATE_CLOSED",
+                                "to": false
+                              },
+                              {
+                                "from": "DOOR_STATE_OPEN_OR_AJAR",
+                                "to": true
+                              },
+                              {
+                                "from": "DOOR_STATE_RELEASING_LATCH",
+                                "to": true
+                              }
+                            ]
+                          }
+                        },
+                        "description": "Is item open or closed? True = Fully or partially open. False = Fully closed.",
+                        "type": "actuator"
+                      },
+                      "Position": {
+                        "comment": "Relationship between Open/Close and Start/End position is item dependent.",
+                        "datatype": "uint8",
+                        "description": "Item position. 0 = Start position 100 = End position.",
+                        "max": 100,
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "Shade": {
+                        "children": {
+                          "IsOpen": {
+                            "datatype": "boolean",
+                            "description": "Is item open or closed? True = Fully or partially open. False = Fully closed.",
+                            "type": "actuator"
+                          },
+                          "Position": {
+                            "comment": "Relationship between Open/Close and Start/End position is item dependent.",
+                            "datatype": "uint8",
+                            "description": "Item position. 0 = Start position 100 = End position.",
+                            "max": 100,
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "Switch": {
+                            "allowed": [
+                              "INACTIVE",
+                              "CLOSE",
+                              "OPEN",
+                              "ONE_SHOT_CLOSE",
+                              "ONE_SHOT_OPEN"
+                            ],
+                            "datatype": "string",
+                            "description": "Switch controlling sliding action such as window, sunroof, or blind.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Side window shade. Open = Retracted, Closed = Deployed. Start position for Shade is Open/Retracted.",
+                        "type": "branch"
+                      },
+                      "Switch": {
+                        "allowed": [
+                          "INACTIVE",
+                          "CLOSE",
+                          "OPEN",
+                          "ONE_SHOT_CLOSE",
+                          "ONE_SHOT_OPEN"
+                        ],
+                        "datatype": "string",
+                        "description": "Switch controlling sliding action such as window, sunroof, or blind.",
+                        "type": "actuator"
+                      },
+                      "Window": {
+                        "children": {
+                          "IsOpen": {
+                            "datatype": "boolean",
+                            "description": "Is item open or closed? True = Fully or partially open. False = Fully closed.",
+                            "type": "actuator"
+                          },
+                          "Position": {
+                            "comment": "Relationship between Open/Close and Start/End position is item dependent.",
+                            "datatype": "uint8",
+                            "description": "Item position. 0 = Start position 100 = End position.",
+                            "max": 100,
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "Switch": {
+                            "allowed": [
+                              "INACTIVE",
+                              "CLOSE",
+                              "OPEN",
+                              "ONE_SHOT_CLOSE",
+                              "ONE_SHOT_OPEN"
+                            ],
+                            "datatype": "string",
+                            "description": "Switch controlling sliding action such as window, sunroof, or blind.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Door window status. Start position for Window is Closed.",
+                        "type": "branch"
+                      }
+                    },
+                    "description": "All doors, including windows and switches.",
+                    "type": "branch"
+                  },
+                  "PassengerSide": {
+                    "children": {
+                      "IsChildLockActive": {
+                        "datatype": "boolean",
+                        "description": "Is door child lock active. True = Door cannot be opened from inside. False = Door can be opened from inside.",
+                        "type": "sensor"
+                      },
+                      "IsLocked": {
+                        "datatype": "boolean",
+                        "description": "Is item locked or unlocked. True = Locked. False = Unlocked.",
+                        "type": "actuator"
+                      },
+                      "IsOpen": {
+                        "datatype": "boolean",
+                        "description": "Is item open or closed? True = Fully or partially open. False = Fully closed.",
+                        "type": "actuator"
+                      },
+                      "Position": {
+                        "comment": "Relationship between Open/Close and Start/End position is item dependent.",
+                        "datatype": "uint8",
+                        "description": "Item position. 0 = Start position 100 = End position.",
+                        "max": 100,
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "Shade": {
+                        "children": {
+                          "IsOpen": {
+                            "datatype": "boolean",
+                            "description": "Is item open or closed? True = Fully or partially open. False = Fully closed.",
+                            "type": "actuator"
+                          },
+                          "Position": {
+                            "comment": "Relationship between Open/Close and Start/End position is item dependent.",
+                            "datatype": "uint8",
+                            "description": "Item position. 0 = Start position 100 = End position.",
+                            "max": 100,
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "Switch": {
+                            "allowed": [
+                              "INACTIVE",
+                              "CLOSE",
+                              "OPEN",
+                              "ONE_SHOT_CLOSE",
+                              "ONE_SHOT_OPEN"
+                            ],
+                            "datatype": "string",
+                            "description": "Switch controlling sliding action such as window, sunroof, or blind.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Side window shade. Open = Retracted, Closed = Deployed. Start position for Shade is Open/Retracted.",
+                        "type": "branch"
+                      },
+                      "Switch": {
+                        "allowed": [
+                          "INACTIVE",
+                          "CLOSE",
+                          "OPEN",
+                          "ONE_SHOT_CLOSE",
+                          "ONE_SHOT_OPEN"
+                        ],
+                        "datatype": "string",
+                        "description": "Switch controlling sliding action such as window, sunroof, or blind.",
+                        "type": "actuator"
+                      },
+                      "Window": {
+                        "children": {
+                          "IsOpen": {
+                            "datatype": "boolean",
+                            "description": "Is item open or closed? True = Fully or partially open. False = Fully closed.",
+                            "type": "actuator"
+                          },
+                          "Position": {
+                            "comment": "Relationship between Open/Close and Start/End position is item dependent.",
+                            "datatype": "uint8",
+                            "description": "Item position. 0 = Start position 100 = End position.",
+                            "max": 100,
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "Switch": {
+                            "allowed": [
+                              "INACTIVE",
+                              "CLOSE",
+                              "OPEN",
+                              "ONE_SHOT_CLOSE",
+                              "ONE_SHOT_OPEN"
+                            ],
+                            "datatype": "string",
+                            "description": "Switch controlling sliding action such as window, sunroof, or blind.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Door window status. Start position for Window is Closed.",
+                        "type": "branch"
+                      }
+                    },
+                    "description": "All doors, including windows and switches.",
+                    "type": "branch"
+                  }
+                },
+                "description": "All doors, including windows and switches.",
+                "type": "branch"
+              }
+            },
+            "description": "All doors, including windows and switches.",
+            "type": "branch"
+          },
+          "DoorCount": {
+            "datatype": "uint8",
+            "default": 4,
+            "description": "Number of doors in vehicle.",
+            "type": "attribute"
+          },
+          "DriverPosition": {
+            "allowed": [
+              "LEFT",
+              "MIDDLE",
+              "RIGHT"
+            ],
+            "comment": "Some signals use DriverSide and PassengerSide as instances. If this signal specifies that DriverPosition is LEFT or MIDDLE, then DriverSide refers to left side and PassengerSide to right side. If this signal specifies that DriverPosition is RIGHT, then DriverSide refers to right side and PassengerSide to left side.",
+            "datatype": "string",
+            "description": "The position of the driver seat in row 1.",
+            "type": "attribute"
+          },
+          "HVAC": {
+            "children": {
+              "AmbientAirTemperature": {
+                "datatype": "float",
+                "description": "Ambient air temperature inside the vehicle.",
+                "type": "sensor",
+                "unit": "celsius"
+              },
+              "IsAirConditioningActive": {
+                "datatype": "boolean",
+                "description": "Is Air conditioning active.",
+                "type": "actuator"
+              },
+              "IsAutoPowerOptimize": {
+                "datatype": "boolean",
+                "description": "Auto Power Optimization Flag When set to 'true', the system enables automatic power optimization, dynamically adjusting the power optimization level based on runtime conditions or features managed by the OEM. When set to 'false', manual control of the power optimization level is allowed.",
+                "type": "actuator"
+              },
+              "IsFrontDefrosterActive": {
+                "datatype": "boolean",
+                "description": "Is front defroster active.",
+                "type": "actuator"
+              },
+              "IsRearDefrosterActive": {
+                "datatype": "boolean",
+                "description": "Is rear defroster active.",
+                "type": "actuator"
+              },
+              "IsRecirculationActive": {
+                "datatype": "boolean",
+                "description": "Is recirculation active.",
+                "type": "actuator"
+              },
+              "PowerOptimizeLevel": {
+                "datatype": "uint8",
+                "description": "Power optimization level for this branch/subsystem. A higher number indicates more aggressive power optimization. Level 0 indicates that all functionality is enabled, no power optimization enabled. Level 10 indicates most aggressive power optimization mode, only essential functionality enabled.",
+                "max": 10,
+                "min": 0,
+                "type": "actuator"
+              },
+              "Station": {
+                "children": {
+                  "Row1": {
+                    "children": {
+                      "Driver": {
+                        "children": {
+                          "AirDistribution": {
+                            "allowed": [
+                              "UP",
+                              "MIDDLE",
+                              "DOWN"
+                            ],
+                            "datatype": "string",
+                            "description": "Direction of airstream",
+                            "type": "actuator"
+                          },
+                          "FanSpeed": {
+                            "datatype": "uint8",
+                            "description": "Fan Speed, 0 = off. 100 = max",
+                            "max": 100,
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "Temperature": {
+                            "datatype": "int8",
+                            "description": "Temperature",
+                            "type": "actuator",
+                            "unit": "celsius"
+                          }
+                        },
+                        "description": "HVAC for single station in the vehicle",
+                        "type": "branch"
+                      },
+                      "Passenger": {
+                        "children": {
+                          "AirDistribution": {
+                            "allowed": [
+                              "UP",
+                              "MIDDLE",
+                              "DOWN"
+                            ],
+                            "datatype": "string",
+                            "description": "Direction of airstream",
+                            "type": "actuator"
+                          },
+                          "FanSpeed": {
+                            "datatype": "uint8",
+                            "description": "Fan Speed, 0 = off. 100 = max",
+                            "max": 100,
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "Temperature": {
+                            "datatype": "int8",
+                            "description": "Temperature",
+                            "type": "actuator",
+                            "unit": "celsius"
+                          }
+                        },
+                        "description": "HVAC for single station in the vehicle",
+                        "type": "branch"
+                      }
+                    },
+                    "description": "HVAC for single station in the vehicle",
+                    "type": "branch"
+                  },
+                  "Row2": {
+                    "children": {
+                      "Driver": {
+                        "children": {
+                          "AirDistribution": {
+                            "allowed": [
+                              "UP",
+                              "MIDDLE",
+                              "DOWN"
+                            ],
+                            "datatype": "string",
+                            "description": "Direction of airstream",
+                            "type": "actuator"
+                          },
+                          "FanSpeed": {
+                            "datatype": "uint8",
+                            "description": "Fan Speed, 0 = off. 100 = max",
+                            "max": 100,
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "Temperature": {
+                            "datatype": "int8",
+                            "description": "Temperature",
+                            "type": "actuator",
+                            "unit": "celsius"
+                          }
+                        },
+                        "description": "HVAC for single station in the vehicle",
+                        "type": "branch"
+                      },
+                      "Passenger": {
+                        "children": {
+                          "AirDistribution": {
+                            "allowed": [
+                              "UP",
+                              "MIDDLE",
+                              "DOWN"
+                            ],
+                            "datatype": "string",
+                            "description": "Direction of airstream",
+                            "type": "actuator"
+                          },
+                          "FanSpeed": {
+                            "datatype": "uint8",
+                            "description": "Fan Speed, 0 = off. 100 = max",
+                            "max": 100,
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "Temperature": {
+                            "datatype": "int8",
+                            "description": "Temperature",
+                            "type": "actuator",
+                            "unit": "celsius"
+                          }
+                        },
+                        "description": "HVAC for single station in the vehicle",
+                        "type": "branch"
+                      }
+                    },
+                    "description": "HVAC for single station in the vehicle",
+                    "type": "branch"
+                  },
+                  "Row3": {
+                    "children": {
+                      "Driver": {
+                        "children": {
+                          "AirDistribution": {
+                            "allowed": [
+                              "UP",
+                              "MIDDLE",
+                              "DOWN"
+                            ],
+                            "datatype": "string",
+                            "description": "Direction of airstream",
+                            "type": "actuator"
+                          },
+                          "FanSpeed": {
+                            "datatype": "uint8",
+                            "description": "Fan Speed, 0 = off. 100 = max",
+                            "max": 100,
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "Temperature": {
+                            "datatype": "int8",
+                            "description": "Temperature",
+                            "type": "actuator",
+                            "unit": "celsius"
+                          }
+                        },
+                        "description": "HVAC for single station in the vehicle",
+                        "type": "branch"
+                      },
+                      "Passenger": {
+                        "children": {
+                          "AirDistribution": {
+                            "allowed": [
+                              "UP",
+                              "MIDDLE",
+                              "DOWN"
+                            ],
+                            "datatype": "string",
+                            "description": "Direction of airstream",
+                            "type": "actuator"
+                          },
+                          "FanSpeed": {
+                            "datatype": "uint8",
+                            "description": "Fan Speed, 0 = off. 100 = max",
+                            "max": 100,
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "Temperature": {
+                            "datatype": "int8",
+                            "description": "Temperature",
+                            "type": "actuator",
+                            "unit": "celsius"
+                          }
+                        },
+                        "description": "HVAC for single station in the vehicle",
+                        "type": "branch"
+                      }
+                    },
+                    "description": "HVAC for single station in the vehicle",
+                    "type": "branch"
+                  },
+                  "Row4": {
+                    "children": {
+                      "Driver": {
+                        "children": {
+                          "AirDistribution": {
+                            "allowed": [
+                              "UP",
+                              "MIDDLE",
+                              "DOWN"
+                            ],
+                            "datatype": "string",
+                            "description": "Direction of airstream",
+                            "type": "actuator"
+                          },
+                          "FanSpeed": {
+                            "datatype": "uint8",
+                            "description": "Fan Speed, 0 = off. 100 = max",
+                            "max": 100,
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "Temperature": {
+                            "datatype": "int8",
+                            "description": "Temperature",
+                            "type": "actuator",
+                            "unit": "celsius"
+                          }
+                        },
+                        "description": "HVAC for single station in the vehicle",
+                        "type": "branch"
+                      },
+                      "Passenger": {
+                        "children": {
+                          "AirDistribution": {
+                            "allowed": [
+                              "UP",
+                              "MIDDLE",
+                              "DOWN"
+                            ],
+                            "datatype": "string",
+                            "description": "Direction of airstream",
+                            "type": "actuator"
+                          },
+                          "FanSpeed": {
+                            "datatype": "uint8",
+                            "description": "Fan Speed, 0 = off. 100 = max",
+                            "max": 100,
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "Temperature": {
+                            "datatype": "int8",
+                            "description": "Temperature",
+                            "type": "actuator",
+                            "unit": "celsius"
+                          }
+                        },
+                        "description": "HVAC for single station in the vehicle",
+                        "type": "branch"
+                      }
+                    },
+                    "description": "HVAC for single station in the vehicle",
+                    "type": "branch"
+                  }
+                },
+                "description": "HVAC for single station in the vehicle",
+                "type": "branch"
+              }
+            },
+            "description": "Climate control",
+            "type": "branch"
+          },
+          "Infotainment": {
+            "children": {
+              "HMI": {
+                "children": {
+                  "Brightness": {
+                    "comment": "The value 0 does not necessarily correspond to a turned off HMI, as it may not be allowed/supported to turn off the HMI completely.",
+                    "datatype": "float",
+                    "description": "Brightness of the HMI, relative to supported range. 0 = Lowest brightness possible. 100 = Maximum Brightness possible.",
+                    "max": 100,
+                    "min": 0,
+                    "type": "actuator",
+                    "unit": "percent"
+                  },
+                  "CurrentLanguage": {
+                    "datatype": "string",
+                    "description": "ISO 639-1 standard language code for the current HMI",
+                    "type": "sensor"
+                  },
+                  "DateFormat": {
+                    "allowed": [
+                      "YYYY_MM_DD",
+                      "DD_MM_YYYY",
+                      "MM_DD_YYYY",
+                      "YY_MM_DD",
+                      "DD_MM_YY",
+                      "MM_DD_YY"
+                    ],
+                    "datatype": "string",
+                    "description": "Date format used in the current HMI",
+                    "type": "actuator"
+                  },
+                  "DayNightMode": {
+                    "allowed": [
+                      "DAY",
+                      "NIGHT"
+                    ],
+                    "datatype": "string",
+                    "description": "Current display theme",
+                    "type": "actuator"
+                  },
+                  "DisplayOffDuration": {
+                    "comment": "Display shall be turned off at HMI.LastActionTime + HMI.DisplayOffDuration, unless HMI.IsScreenAlwaysOn==True.",
+                    "datatype": "uint16",
+                    "description": "Duration in seconds before the display is turned off. Value shall be 0 if screen never shall turn off.",
+                    "type": "actuator",
+                    "unit": "s"
+                  },
+                  "DistanceUnit": {
+                    "allowed": [
+                      "MILES",
+                      "KILOMETERS"
+                    ],
+                    "datatype": "string",
+                    "description": "Distance unit used in the current HMI",
+                    "type": "actuator"
+                  },
+                  "EVEconomyUnits": {
+                    "allowed": [
+                      "MILES_PER_KILOWATT_HOUR",
+                      "KILOMETERS_PER_KILOWATT_HOUR",
+                      "KILOWATT_HOURS_PER_100_MILES",
+                      "KILOWATT_HOURS_PER_100_KILOMETERS",
+                      "WATT_HOURS_PER_MILE",
+                      "WATT_HOURS_PER_KILOMETER"
+                    ],
+                    "datatype": "string",
+                    "description": "EV fuel economy unit used in the current HMI",
+                    "type": "actuator"
+                  },
+                  "EVEnergyUnits": {
+                    "allowed": [
+                      "WATT_HOURS",
+                      "AMPERE_HOURS",
+                      "KILOWATT_HOURS"
+                    ],
+                    "comment": "Ampere hours is by definition not an energy unit, but can be used as a measurement of energy if the voltage, like nominal voltage of the battery, is known.",
+                    "datatype": "string",
+                    "description": "EV energy unit used in the current HMI",
+                    "type": "actuator"
+                  },
+                  "FontSize": {
+                    "allowed": [
+                      "STANDARD",
+                      "LARGE",
+                      "EXTRA_LARGE"
+                    ],
+                    "datatype": "string",
+                    "description": "Font size used in the current HMI",
+                    "type": "actuator"
+                  },
+                  "FuelEconomyUnits": {
+                    "allowed": [
+                      "MPG_UK",
+                      "MPG_US",
+                      "MILES_PER_LITER",
+                      "KILOMETERS_PER_LITER",
+                      "LITERS_PER_100_KILOMETERS"
+                    ],
+                    "datatype": "string",
+                    "description": "Fuel economy unit used in the current HMI",
+                    "type": "actuator"
+                  },
+                  "FuelVolumeUnit": {
+                    "allowed": [
+                      "LITER",
+                      "GALLON_US",
+                      "GALLON_UK"
+                    ],
+                    "datatype": "string",
+                    "description": "Fuel volume unit used in the current HMI",
+                    "type": "actuator"
+                  },
+                  "IsScreenAlwaysOn": {
+                    "datatype": "boolean",
+                    "description": "Used to prevent the screen going black if no action placed.",
+                    "type": "actuator"
+                  },
+                  "LastActionTime": {
+                    "datatype": "string",
+                    "description": "Time for last hmi action, formatted according to ISO 8601 with UTC time zone.",
+                    "type": "sensor",
+                    "unit": "iso8601"
+                  },
+                  "SpeedUnit": {
+                    "allowed": [
+                      "METERS_PER_SECOND",
+                      "MILES_PER_HOUR",
+                      "KILOMETERS_PER_HOUR"
+                    ],
+                    "datatype": "string",
+                    "dbc2vss": {
+                      "interval_ms": 100,
+                      "signal": "DI_uiSpeedUnits",
+                      "transform": {
+                        "mapping": [
+                          {
+                            "from": "DI_SPEED_MPH",
+                            "to": "MILES_PER_HOUR"
+                          },
+                          {
+                            "from": "DI_SPEED_KPH",
+                            "to": "KILOMETERS_PER_HOUR"
+                          }
+                        ]
+                      }
+                    },
+                    "description": "Customized speed unit - using string and implicit conversion",
+                    "type": "actuator"
+                  },
+                  "TemperatureUnit": {
+                    "allowed": [
+                      "C",
+                      "F"
+                    ],
+                    "datatype": "string",
+                    "description": "Temperature unit used in the current HMI",
+                    "type": "actuator"
+                  },
+                  "TimeFormat": {
+                    "allowed": [
+                      "HR_12",
+                      "HR_24"
+                    ],
+                    "datatype": "string",
+                    "description": "Time format used in the current HMI",
+                    "type": "actuator"
+                  },
+                  "TirePressureUnit": {
+                    "allowed": [
+                      "PSI",
+                      "KPA",
+                      "BAR"
+                    ],
+                    "datatype": "string",
+                    "description": "Tire pressure unit used in the current HMI",
+                    "type": "actuator"
+                  }
+                },
+                "description": "HMI related signals",
+                "type": "branch"
+              },
+              "IsAutoPowerOptimize": {
+                "datatype": "boolean",
+                "description": "Auto Power Optimization Flag When set to 'true', the system enables automatic power optimization, dynamically adjusting the power optimization level based on runtime conditions or features managed by the OEM. When set to 'false', manual control of the power optimization level is allowed.",
+                "type": "actuator"
+              },
+              "Media": {
+                "children": {
+                  "Action": {
+                    "allowed": [
+                      "UNKNOWN",
+                      "STOP",
+                      "PLAY",
+                      "FAST_FORWARD",
+                      "FAST_BACKWARD",
+                      "SKIP_FORWARD",
+                      "SKIP_BACKWARD"
+                    ],
+                    "datatype": "string",
+                    "description": "Tells if the media was",
+                    "type": "actuator"
+                  },
+                  "DeclinedURI": {
+                    "datatype": "string",
+                    "description": "URI of suggested media that was declined",
+                    "type": "sensor"
+                  },
+                  "Played": {
+                    "children": {
+                      "Album": {
+                        "datatype": "string",
+                        "dbc2vss": {
+                          "interval_ms": 100,
+                          "signal": "DI_uiSpeedUnits"
+                        },
+                        "description": "Name of album being played",
+                        "type": "sensor"
+                      },
+                      "Artist": {
+                        "datatype": "string",
+                        "description": "Name of artist being played",
+                        "type": "sensor"
+                      },
+                      "PlaybackRate": {
+                        "comment": "The normal playback rate is multiplied by this value to obtain the current rate, so a value of 1.0 indicates normal speed. Values of lower than 1.0 make the media play slower than normal. Values of higher than 1.0 make the media play faster than normal.",
+                        "datatype": "float",
+                        "description": "Current playback rate of media being played.",
+                        "type": "actuator"
+                      },
+                      "Source": {
+                        "allowed": [
+                          "UNKNOWN",
+                          "SIRIUS_XM",
+                          "AM",
+                          "FM",
+                          "DAB",
+                          "TV",
+                          "CD",
+                          "DVD",
+                          "AUX",
+                          "USB",
+                          "DISK",
+                          "BLUETOOTH",
+                          "INTERNET",
+                          "VOICE",
+                          "BEEP"
+                        ],
+                        "datatype": "string",
+                        "description": "Media selected for playback",
+                        "type": "actuator"
+                      },
+                      "Track": {
+                        "datatype": "string",
+                        "description": "Name of track being played",
+                        "type": "sensor"
+                      },
+                      "URI": {
+                        "datatype": "string",
+                        "description": "User Resource associated with the media",
+                        "type": "sensor"
+                      }
+                    },
+                    "description": "Collection of signals updated in concert when a new media is played",
+                    "type": "branch"
+                  },
+                  "SelectedURI": {
+                    "datatype": "string",
+                    "description": "URI of suggested media that was selected",
+                    "type": "actuator"
+                  },
+                  "Volume": {
+                    "datatype": "uint8",
+                    "dbc2vss": {
+                      "interval_ms": 100,
+                      "signal": "DI_uiSpeedUnits"
+                    },
+                    "description": "Current Media Volume",
+                    "max": 100,
+                    "min": 0,
+                    "type": "actuator",
+                    "unit": "percent"
+                  }
+                },
+                "description": "All Media actions",
+                "type": "branch"
+              },
+              "Navigation": {
+                "children": {
+                  "DestinationSet": {
+                    "children": {
+                      "Latitude": {
+                        "datatype": "double",
+                        "description": "Latitude of destination in WGS 84 geodetic coordinates.",
+                        "max": 90,
+                        "min": -90,
+                        "type": "actuator",
+                        "unit": "degrees"
+                      },
+                      "Longitude": {
+                        "datatype": "double",
+                        "description": "Longitude of destination in WGS 84 geodetic coordinates.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "actuator",
+                        "unit": "degrees"
+                      }
+                    },
+                    "description": "A navigation has been selected.",
+                    "type": "branch"
+                  },
+                  "GuidanceVoice": {
+                    "allowed": [
+                      "STANDARD_MALE",
+                      "STANDARD_FEMALE",
+                      "ETC"
+                    ],
+                    "comment": "ETC indicates a voice alternative not covered by the explicitly listed alternatives.",
+                    "datatype": "string",
+                    "description": "Navigation guidance state that was selected.",
+                    "type": "actuator"
+                  },
+                  "Map": {
+                    "children": {
+                      "IsAutoScaleModeUsed": {
+                        "comment": "If true, then auto-scaling mode is used. If false, then manual-scaling mode is used.",
+                        "datatype": "boolean",
+                        "description": "Used to select auto-scaling mode. This feature dynamically adjusts the zoom level of the map to provide an optimal view based on the current speed of the vehicle",
+                        "type": "actuator"
+                      }
+                    },
+                    "description": "All map actions",
+                    "type": "branch"
+                  },
+                  "Mute": {
+                    "allowed": [
+                      "MUTED",
+                      "ALERT_ONLY",
+                      "UNMUTED"
+                    ],
+                    "datatype": "string",
+                    "description": "Navigation mute state that was selected.",
+                    "type": "actuator"
+                  },
+                  "Volume": {
+                    "datatype": "uint8",
+                    "description": "Current navigation volume",
+                    "max": 100,
+                    "min": 0,
+                    "type": "actuator",
+                    "unit": "percent"
+                  }
+                },
+                "description": "All navigation actions",
+                "type": "branch"
+              },
+              "PowerOptimizeLevel": {
+                "datatype": "uint8",
+                "description": "Power optimization level for this branch/subsystem. A higher number indicates more aggressive power optimization. Level 0 indicates that all functionality is enabled, no power optimization enabled. Level 10 indicates most aggressive power optimization mode, only essential functionality enabled.",
+                "max": 10,
+                "min": 0,
+                "type": "actuator"
+              },
+              "SmartphoneProjection": {
+                "children": {
+                  "Active": {
+                    "allowed": [
+                      "NONE",
+                      "ACTIVE",
+                      "INACTIVE"
+                    ],
+                    "comment": "NONE indicates that projection is not supported.",
+                    "datatype": "string",
+                    "description": "Projection activation info.",
+                    "type": "actuator"
+                  },
+                  "Source": {
+                    "allowed": [
+                      "USB",
+                      "BLUETOOTH",
+                      "WIFI"
+                    ],
+                    "comment": "Smartphone projection exposes or controls specific applications on the Smartphone on the vehicle infotainment system.",
+                    "datatype": "string",
+                    "description": "Connectivity source selected for projection.",
+                    "type": "actuator"
+                  },
+                  "SupportedMode": {
+                    "allowed": [
+                      "ANDROID_AUTO",
+                      "APPLE_CARPLAY",
+                      "MIRROR_LINK",
+                      "OTHER"
+                    ],
+                    "datatype": "string[]",
+                    "description": "Supportable list for projection.",
+                    "type": "attribute"
+                  }
+                },
+                "comment": "Smartphone projection exposes or controls specific applications on the Smartphone on the vehicle infotainment system.",
+                "description": "All smartphone projection actions.",
+                "type": "branch"
+              },
+              "SmartphoneScreenMirroring": {
+                "children": {
+                  "Active": {
+                    "allowed": [
+                      "NONE",
+                      "ACTIVE",
+                      "INACTIVE"
+                    ],
+                    "comment": "NONE indicates that mirroring is not supported.",
+                    "datatype": "string",
+                    "description": "Mirroring activation info.",
+                    "type": "actuator"
+                  },
+                  "Source": {
+                    "allowed": [
+                      "USB",
+                      "BLUETOOTH",
+                      "WIFI"
+                    ],
+                    "datatype": "string",
+                    "description": "Connectivity source selected for mirroring.",
+                    "type": "actuator"
+                  }
+                },
+                "comment": "Smartphone screen mirroring mirrors the whole screen of the Smartphone on the vehicle infotainment system.",
+                "description": "All smartphone screen mirroring actions.",
+                "type": "branch"
+              }
+            },
+            "description": "Infotainment system.",
+            "type": "branch"
+          },
+          "IsAutoPowerOptimize": {
+            "datatype": "boolean",
+            "description": "Auto Power Optimization Flag When set to 'true', the system enables automatic power optimization, dynamically adjusting the power optimization level based on runtime conditions or features managed by the OEM. When set to 'false', manual control of the power optimization level is allowed.",
+            "type": "actuator"
+          },
+          "IsWindowChildLockEngaged": {
+            "comment": "Window child lock refers to the functionality to disable the move window button next to most windows, so that they only can be operated by the driver.",
+            "datatype": "boolean",
+            "description": "Is window child lock engaged. True = Engaged. False = Disengaged.",
+            "type": "actuator"
+          },
+          "Light": {
+            "children": {
+              "AmbientLight": {
+                "children": {
+                  "Row1": {
+                    "children": {
+                      "DriverSide": {
+                        "children": {
+                          "Color": {
+                            "comment": "For example; \"#C0C0C0\" = Silver, \"#FFD700\" = Gold, \"#000000\" = Black, \"#FFFFFF\" = White, etc.",
+                            "datatype": "string",
+                            "description": "Hexadecimal color code represented as a 3-byte RGB (i.e. Red, Green, and Blue) value preceded by a hash symbol \"#\". Allowed range \"#000000\" to \"#FFFFFF\".",
+                            "type": "actuator"
+                          },
+                          "Intensity": {
+                            "comment": "Minimum value cannot be zero as on/off is controlled by the actuator IsLightOn. V4.0 moved from Cabin.Lights.AmbientLight.Intensity to enable individual control of lights via the SingleConfigurableLight.vspec.",
+                            "datatype": "uint8",
+                            "description": "How much of the maximum possible brightness of the light is used. 1 = Maximum attenuation, 100 = No attenuation (i.e. full brightness).",
+                            "max": 100,
+                            "min": 1,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "IsLightOn": {
+                            "datatype": "boolean",
+                            "description": "Indicates whether the light is turned on. True = On, False = Off.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Decorative coloured light inside the cabin, usually mounted on the door, ceiling, etc.",
+                        "type": "branch"
+                      },
+                      "PassengerSide": {
+                        "children": {
+                          "Color": {
+                            "comment": "For example; \"#C0C0C0\" = Silver, \"#FFD700\" = Gold, \"#000000\" = Black, \"#FFFFFF\" = White, etc.",
+                            "datatype": "string",
+                            "description": "Hexadecimal color code represented as a 3-byte RGB (i.e. Red, Green, and Blue) value preceded by a hash symbol \"#\". Allowed range \"#000000\" to \"#FFFFFF\".",
+                            "type": "actuator"
+                          },
+                          "Intensity": {
+                            "comment": "Minimum value cannot be zero as on/off is controlled by the actuator IsLightOn. V4.0 moved from Cabin.Lights.AmbientLight.Intensity to enable individual control of lights via the SingleConfigurableLight.vspec.",
+                            "datatype": "uint8",
+                            "description": "How much of the maximum possible brightness of the light is used. 1 = Maximum attenuation, 100 = No attenuation (i.e. full brightness).",
+                            "max": 100,
+                            "min": 1,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "IsLightOn": {
+                            "datatype": "boolean",
+                            "description": "Indicates whether the light is turned on. True = On, False = Off.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Decorative coloured light inside the cabin, usually mounted on the door, ceiling, etc.",
+                        "type": "branch"
+                      }
+                    },
+                    "description": "Decorative coloured light inside the cabin, usually mounted on the door, ceiling, etc.",
+                    "type": "branch"
+                  },
+                  "Row2": {
+                    "children": {
+                      "DriverSide": {
+                        "children": {
+                          "Color": {
+                            "comment": "For example; \"#C0C0C0\" = Silver, \"#FFD700\" = Gold, \"#000000\" = Black, \"#FFFFFF\" = White, etc.",
+                            "datatype": "string",
+                            "description": "Hexadecimal color code represented as a 3-byte RGB (i.e. Red, Green, and Blue) value preceded by a hash symbol \"#\". Allowed range \"#000000\" to \"#FFFFFF\".",
+                            "type": "actuator"
+                          },
+                          "Intensity": {
+                            "comment": "Minimum value cannot be zero as on/off is controlled by the actuator IsLightOn. V4.0 moved from Cabin.Lights.AmbientLight.Intensity to enable individual control of lights via the SingleConfigurableLight.vspec.",
+                            "datatype": "uint8",
+                            "description": "How much of the maximum possible brightness of the light is used. 1 = Maximum attenuation, 100 = No attenuation (i.e. full brightness).",
+                            "max": 100,
+                            "min": 1,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "IsLightOn": {
+                            "datatype": "boolean",
+                            "description": "Indicates whether the light is turned on. True = On, False = Off.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Decorative coloured light inside the cabin, usually mounted on the door, ceiling, etc.",
+                        "type": "branch"
+                      },
+                      "PassengerSide": {
+                        "children": {
+                          "Color": {
+                            "comment": "For example; \"#C0C0C0\" = Silver, \"#FFD700\" = Gold, \"#000000\" = Black, \"#FFFFFF\" = White, etc.",
+                            "datatype": "string",
+                            "description": "Hexadecimal color code represented as a 3-byte RGB (i.e. Red, Green, and Blue) value preceded by a hash symbol \"#\". Allowed range \"#000000\" to \"#FFFFFF\".",
+                            "type": "actuator"
+                          },
+                          "Intensity": {
+                            "comment": "Minimum value cannot be zero as on/off is controlled by the actuator IsLightOn. V4.0 moved from Cabin.Lights.AmbientLight.Intensity to enable individual control of lights via the SingleConfigurableLight.vspec.",
+                            "datatype": "uint8",
+                            "description": "How much of the maximum possible brightness of the light is used. 1 = Maximum attenuation, 100 = No attenuation (i.e. full brightness).",
+                            "max": 100,
+                            "min": 1,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "IsLightOn": {
+                            "datatype": "boolean",
+                            "description": "Indicates whether the light is turned on. True = On, False = Off.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Decorative coloured light inside the cabin, usually mounted on the door, ceiling, etc.",
+                        "type": "branch"
+                      }
+                    },
+                    "description": "Decorative coloured light inside the cabin, usually mounted on the door, ceiling, etc.",
+                    "type": "branch"
+                  }
+                },
+                "description": "Decorative coloured light inside the cabin, usually mounted on the door, ceiling, etc.",
+                "type": "branch"
+              },
+              "InteractiveLightBar": {
+                "children": {
+                  "Color": {
+                    "comment": "For example; \"#C0C0C0\" = Silver, \"#FFD700\" = Gold, \"#000000\" = Black, \"#FFFFFF\" = White, etc.",
+                    "datatype": "string",
+                    "description": "Hexadecimal color code represented as a 3-byte RGB (i.e. Red, Green, and Blue) value preceded by a hash symbol \"#\". Allowed range \"#000000\" to \"#FFFFFF\".",
+                    "type": "actuator"
+                  },
+                  "Effect": {
+                    "comment": "Default and allowed values are OEM-specific and should be defined accordingly (e.g. with the use of overlays).",
+                    "datatype": "string",
+                    "description": "Light effect selection from a predefined set of allowed values.",
+                    "type": "actuator"
+                  },
+                  "Intensity": {
+                    "comment": "Minimum value cannot be zero as on/off is controlled by the actuator IsLightOn. V4.0 moved from Cabin.Lights.AmbientLight.Intensity to enable individual control of lights via the SingleConfigurableLight.vspec.",
+                    "datatype": "uint8",
+                    "description": "How much of the maximum possible brightness of the light is used. 1 = Maximum attenuation, 100 = No attenuation (i.e. full brightness).",
+                    "max": 100,
+                    "min": 1,
+                    "type": "actuator",
+                    "unit": "percent"
+                  },
+                  "IsLightOn": {
+                    "datatype": "boolean",
+                    "description": "Indicates whether the light is turned on. True = On, False = Off.",
+                    "type": "actuator"
+                  }
+                },
+                "description": "Decorative coloured light bar that supports effects, usually mounted on the dashboard (e.g. BMW i7 Interactive bar).",
+                "type": "branch"
+              },
+              "IsDomeOn": {
+                "datatype": "boolean",
+                "description": "Is central dome light on",
+                "type": "actuator"
+              },
+              "IsGloveBoxOn": {
+                "datatype": "boolean",
+                "description": "Is glove box light on",
+                "type": "actuator"
+              },
+              "PerceivedAmbientLight": {
+                "comment": "V4.0 named changed from \"AmbientLight\" to \"PerceivedAmbientLight\". This is a read-only property that refers to the pre-existing light (e.g., natural light). If you are looking for the in-cabin decorative lights that sometimes are also called \"AmbientLights\", please refer to the branch Vehicle.Cabin.Light.AmbientLight.",
+                "datatype": "uint8",
+                "description": "The percentage of ambient light that is measured (e.g., by a sensor) inside the cabin. 0 = No ambient light. 100 = Full brightness.",
+                "max": 100,
+                "min": 0,
+                "type": "sensor",
+                "unit": "percent"
+              },
+              "Spotlight": {
+                "children": {
+                  "Row1": {
+                    "children": {
+                      "DriverSide": {
+                        "children": {
+                          "Color": {
+                            "comment": "For example; \"#C0C0C0\" = Silver, \"#FFD700\" = Gold, \"#000000\" = Black, \"#FFFFFF\" = White, etc.",
+                            "datatype": "string",
+                            "description": "Hexadecimal color code represented as a 3-byte RGB (i.e. Red, Green, and Blue) value preceded by a hash symbol \"#\". Allowed range \"#000000\" to \"#FFFFFF\".",
+                            "type": "actuator"
+                          },
+                          "Intensity": {
+                            "comment": "Minimum value cannot be zero as on/off is controlled by the actuator IsLightOn. V4.0 moved from Cabin.Lights.AmbientLight.Intensity to enable individual control of lights via the SingleConfigurableLight.vspec.",
+                            "datatype": "uint8",
+                            "description": "How much of the maximum possible brightness of the light is used. 1 = Maximum attenuation, 100 = No attenuation (i.e. full brightness).",
+                            "max": 100,
+                            "min": 1,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "IsLightOn": {
+                            "datatype": "boolean",
+                            "description": "Indicates whether the light is turned on. True = On, False = Off.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Spotlight for a specific area in the vehicle.",
+                        "type": "branch"
+                      },
+                      "PassengerSide": {
+                        "children": {
+                          "Color": {
+                            "comment": "For example; \"#C0C0C0\" = Silver, \"#FFD700\" = Gold, \"#000000\" = Black, \"#FFFFFF\" = White, etc.",
+                            "datatype": "string",
+                            "description": "Hexadecimal color code represented as a 3-byte RGB (i.e. Red, Green, and Blue) value preceded by a hash symbol \"#\". Allowed range \"#000000\" to \"#FFFFFF\".",
+                            "type": "actuator"
+                          },
+                          "Intensity": {
+                            "comment": "Minimum value cannot be zero as on/off is controlled by the actuator IsLightOn. V4.0 moved from Cabin.Lights.AmbientLight.Intensity to enable individual control of lights via the SingleConfigurableLight.vspec.",
+                            "datatype": "uint8",
+                            "description": "How much of the maximum possible brightness of the light is used. 1 = Maximum attenuation, 100 = No attenuation (i.e. full brightness).",
+                            "max": 100,
+                            "min": 1,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "IsLightOn": {
+                            "datatype": "boolean",
+                            "description": "Indicates whether the light is turned on. True = On, False = Off.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Spotlight for a specific area in the vehicle.",
+                        "type": "branch"
+                      }
+                    },
+                    "description": "Spotlight for a specific area in the vehicle.",
+                    "type": "branch"
+                  },
+                  "Row2": {
+                    "children": {
+                      "DriverSide": {
+                        "children": {
+                          "Color": {
+                            "comment": "For example; \"#C0C0C0\" = Silver, \"#FFD700\" = Gold, \"#000000\" = Black, \"#FFFFFF\" = White, etc.",
+                            "datatype": "string",
+                            "description": "Hexadecimal color code represented as a 3-byte RGB (i.e. Red, Green, and Blue) value preceded by a hash symbol \"#\". Allowed range \"#000000\" to \"#FFFFFF\".",
+                            "type": "actuator"
+                          },
+                          "Intensity": {
+                            "comment": "Minimum value cannot be zero as on/off is controlled by the actuator IsLightOn. V4.0 moved from Cabin.Lights.AmbientLight.Intensity to enable individual control of lights via the SingleConfigurableLight.vspec.",
+                            "datatype": "uint8",
+                            "description": "How much of the maximum possible brightness of the light is used. 1 = Maximum attenuation, 100 = No attenuation (i.e. full brightness).",
+                            "max": 100,
+                            "min": 1,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "IsLightOn": {
+                            "datatype": "boolean",
+                            "description": "Indicates whether the light is turned on. True = On, False = Off.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Spotlight for a specific area in the vehicle.",
+                        "type": "branch"
+                      },
+                      "PassengerSide": {
+                        "children": {
+                          "Color": {
+                            "comment": "For example; \"#C0C0C0\" = Silver, \"#FFD700\" = Gold, \"#000000\" = Black, \"#FFFFFF\" = White, etc.",
+                            "datatype": "string",
+                            "description": "Hexadecimal color code represented as a 3-byte RGB (i.e. Red, Green, and Blue) value preceded by a hash symbol \"#\". Allowed range \"#000000\" to \"#FFFFFF\".",
+                            "type": "actuator"
+                          },
+                          "Intensity": {
+                            "comment": "Minimum value cannot be zero as on/off is controlled by the actuator IsLightOn. V4.0 moved from Cabin.Lights.AmbientLight.Intensity to enable individual control of lights via the SingleConfigurableLight.vspec.",
+                            "datatype": "uint8",
+                            "description": "How much of the maximum possible brightness of the light is used. 1 = Maximum attenuation, 100 = No attenuation (i.e. full brightness).",
+                            "max": 100,
+                            "min": 1,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "IsLightOn": {
+                            "datatype": "boolean",
+                            "description": "Indicates whether the light is turned on. True = On, False = Off.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Spotlight for a specific area in the vehicle.",
+                        "type": "branch"
+                      }
+                    },
+                    "description": "Spotlight for a specific area in the vehicle.",
+                    "type": "branch"
+                  },
+                  "Row3": {
+                    "children": {
+                      "DriverSide": {
+                        "children": {
+                          "Color": {
+                            "comment": "For example; \"#C0C0C0\" = Silver, \"#FFD700\" = Gold, \"#000000\" = Black, \"#FFFFFF\" = White, etc.",
+                            "datatype": "string",
+                            "description": "Hexadecimal color code represented as a 3-byte RGB (i.e. Red, Green, and Blue) value preceded by a hash symbol \"#\". Allowed range \"#000000\" to \"#FFFFFF\".",
+                            "type": "actuator"
+                          },
+                          "Intensity": {
+                            "comment": "Minimum value cannot be zero as on/off is controlled by the actuator IsLightOn. V4.0 moved from Cabin.Lights.AmbientLight.Intensity to enable individual control of lights via the SingleConfigurableLight.vspec.",
+                            "datatype": "uint8",
+                            "description": "How much of the maximum possible brightness of the light is used. 1 = Maximum attenuation, 100 = No attenuation (i.e. full brightness).",
+                            "max": 100,
+                            "min": 1,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "IsLightOn": {
+                            "datatype": "boolean",
+                            "description": "Indicates whether the light is turned on. True = On, False = Off.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Spotlight for a specific area in the vehicle.",
+                        "type": "branch"
+                      },
+                      "PassengerSide": {
+                        "children": {
+                          "Color": {
+                            "comment": "For example; \"#C0C0C0\" = Silver, \"#FFD700\" = Gold, \"#000000\" = Black, \"#FFFFFF\" = White, etc.",
+                            "datatype": "string",
+                            "description": "Hexadecimal color code represented as a 3-byte RGB (i.e. Red, Green, and Blue) value preceded by a hash symbol \"#\". Allowed range \"#000000\" to \"#FFFFFF\".",
+                            "type": "actuator"
+                          },
+                          "Intensity": {
+                            "comment": "Minimum value cannot be zero as on/off is controlled by the actuator IsLightOn. V4.0 moved from Cabin.Lights.AmbientLight.Intensity to enable individual control of lights via the SingleConfigurableLight.vspec.",
+                            "datatype": "uint8",
+                            "description": "How much of the maximum possible brightness of the light is used. 1 = Maximum attenuation, 100 = No attenuation (i.e. full brightness).",
+                            "max": 100,
+                            "min": 1,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "IsLightOn": {
+                            "datatype": "boolean",
+                            "description": "Indicates whether the light is turned on. True = On, False = Off.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Spotlight for a specific area in the vehicle.",
+                        "type": "branch"
+                      }
+                    },
+                    "description": "Spotlight for a specific area in the vehicle.",
+                    "type": "branch"
+                  },
+                  "Row4": {
+                    "children": {
+                      "DriverSide": {
+                        "children": {
+                          "Color": {
+                            "comment": "For example; \"#C0C0C0\" = Silver, \"#FFD700\" = Gold, \"#000000\" = Black, \"#FFFFFF\" = White, etc.",
+                            "datatype": "string",
+                            "description": "Hexadecimal color code represented as a 3-byte RGB (i.e. Red, Green, and Blue) value preceded by a hash symbol \"#\". Allowed range \"#000000\" to \"#FFFFFF\".",
+                            "type": "actuator"
+                          },
+                          "Intensity": {
+                            "comment": "Minimum value cannot be zero as on/off is controlled by the actuator IsLightOn. V4.0 moved from Cabin.Lights.AmbientLight.Intensity to enable individual control of lights via the SingleConfigurableLight.vspec.",
+                            "datatype": "uint8",
+                            "description": "How much of the maximum possible brightness of the light is used. 1 = Maximum attenuation, 100 = No attenuation (i.e. full brightness).",
+                            "max": 100,
+                            "min": 1,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "IsLightOn": {
+                            "datatype": "boolean",
+                            "description": "Indicates whether the light is turned on. True = On, False = Off.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Spotlight for a specific area in the vehicle.",
+                        "type": "branch"
+                      },
+                      "PassengerSide": {
+                        "children": {
+                          "Color": {
+                            "comment": "For example; \"#C0C0C0\" = Silver, \"#FFD700\" = Gold, \"#000000\" = Black, \"#FFFFFF\" = White, etc.",
+                            "datatype": "string",
+                            "description": "Hexadecimal color code represented as a 3-byte RGB (i.e. Red, Green, and Blue) value preceded by a hash symbol \"#\". Allowed range \"#000000\" to \"#FFFFFF\".",
+                            "type": "actuator"
+                          },
+                          "Intensity": {
+                            "comment": "Minimum value cannot be zero as on/off is controlled by the actuator IsLightOn. V4.0 moved from Cabin.Lights.AmbientLight.Intensity to enable individual control of lights via the SingleConfigurableLight.vspec.",
+                            "datatype": "uint8",
+                            "description": "How much of the maximum possible brightness of the light is used. 1 = Maximum attenuation, 100 = No attenuation (i.e. full brightness).",
+                            "max": 100,
+                            "min": 1,
+                            "type": "actuator",
+                            "unit": "percent"
+                          },
+                          "IsLightOn": {
+                            "datatype": "boolean",
+                            "description": "Indicates whether the light is turned on. True = On, False = Off.",
+                            "type": "actuator"
+                          }
+                        },
+                        "description": "Spotlight for a specific area in the vehicle.",
+                        "type": "branch"
+                      }
+                    },
+                    "description": "Spotlight for a specific area in the vehicle.",
+                    "type": "branch"
+                  }
+                },
+                "description": "Spotlight for a specific area in the vehicle.",
+                "type": "branch"
+              }
+            },
+            "comment": "V4.0 branch renamed from \"Lights\" to \"Light\" to comply with singular naming of entities. Use SingleConfigurableLight.vspec to describe interior lights that can be configured.",
+            "description": "Light that is part of the Cabin.",
+            "type": "branch"
+          },
+          "PowerOptimizeLevel": {
+            "datatype": "uint8",
+            "description": "Power optimization level for this branch/subsystem. A higher number indicates more aggressive power optimization. Level 0 indicates that all functionality is enabled, no power optimization enabled. Level 10 indicates most aggressive power optimization mode, only essential functionality enabled.",
+            "max": 10,
+            "min": 0,
+            "type": "actuator"
+          },
+          "RearShade": {
+            "children": {
+              "IsOpen": {
+                "datatype": "boolean",
+                "description": "Is item open or closed? True = Fully or partially open. False = Fully closed.",
+                "type": "actuator"
+              },
+              "Position": {
+                "comment": "Relationship between Open/Close and Start/End position is item dependent.",
+                "datatype": "uint8",
+                "description": "Item position. 0 = Start position 100 = End position.",
+                "max": 100,
+                "min": 0,
+                "type": "actuator",
+                "unit": "percent"
+              },
+              "Switch": {
+                "allowed": [
+                  "INACTIVE",
+                  "CLOSE",
+                  "OPEN",
+                  "ONE_SHOT_CLOSE",
+                  "ONE_SHOT_OPEN"
+                ],
+                "datatype": "string",
+                "description": "Switch controlling sliding action such as window, sunroof, or blind.",
+                "type": "actuator"
+              }
+            },
+            "description": "Rear window shade. Open = Retracted, Closed = Deployed. Start position for RearShade is Open/Retracted.",
+            "type": "branch"
+          },
+          "RearviewMirror": {
+            "children": {
+              "DimmingLevel": {
+                "datatype": "uint8",
+                "description": "Dimming level of rear-view mirror. 0 = Undimmed. 100 = Fully dimmed.",
+                "max": 100,
+                "type": "actuator",
+                "unit": "percent"
+              }
+            },
+            "description": "Rear-view mirror.",
+            "type": "branch"
+          },
+          "Seat": {
+            "children": {
+              "Row1": {
+                "children": {
+                  "DriverSide": {
+                    "children": {
+                      "Airbag": {
+                        "children": {
+                          "IsDeployed": {
+                            "datatype": "boolean",
+                            "description": "Airbag deployment status. True = Airbag deployed. False = Airbag not deployed.",
+                            "type": "sensor"
+                          }
+                        },
+                        "description": "Airbag signals.",
+                        "type": "branch"
+                      },
+                      "Backrest": {
+                        "children": {
+                          "Lumbar": {
+                            "children": {
+                              "Height": {
+                                "datatype": "uint8",
+                                "description": "Height of lumbar support. Position is relative within available movable range of the lumbar support. 0 = Lowermost position supported.",
+                                "min": 0,
+                                "type": "actuator",
+                                "unit": "mm"
+                              },
+                              "Support": {
+                                "datatype": "float",
+                                "description": "Lumbar support (in/out position). 0 = Innermost position. 100 = Outermost position.",
+                                "max": 100,
+                                "min": 0,
+                                "type": "actuator",
+                                "unit": "percent"
+                              }
+                            },
+                            "description": "Adjustable lumbar support mechanisms in seats allow the user to change the seat back shape.",
+                            "type": "branch"
+                          },
+                          "Recline": {
+                            "comment": "Seat z-axis depends on seat tilt. This means that movement of backrest due to seat tilting will not affect Backrest.Recline as long as the angle between Seating and Backrest are constant. Absolute recline relative to vehicle z-axis can be calculated as Tilt + Backrest.Recline.",
+                            "datatype": "float",
+                            "description": "Backrest recline compared to seat z-axis (seat vertical axis). 0 degrees = Upright/Vertical backrest. Negative degrees for forward recline. Positive degrees for backward recline.",
+                            "type": "actuator",
+                            "unit": "degrees"
+                          },
+                          "SideBolster": {
+                            "children": {
+                              "Support": {
+                                "datatype": "float",
+                                "description": "Side bolster support. 0 = Minimum support (widest side bolster setting). 100 = Maximum support.",
+                                "max": 100,
+                                "min": 0,
+                                "type": "actuator",
+                                "unit": "percent"
+                              }
+                            },
+                            "description": "Backrest side bolster (lumbar side support) settings.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Describes signals related to the backrest of the seat.",
+                        "type": "branch"
+                      },
+                      "Headrest": {
+                        "children": {
+                          "Angle": {
+                            "datatype": "float",
+                            "description": "Headrest angle, relative to backrest, 0 degrees if parallel to backrest, Positive degrees = tilted forward.",
+                            "type": "actuator",
+                            "unit": "degrees"
+                          },
+                          "Height": {
+                            "datatype": "uint8",
+                            "description": "Position of headrest relative to movable range of the head rest. 0 = Bottommost position supported.",
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "mm"
+                          }
+                        },
+                        "description": "Headrest settings.",
+                        "type": "branch"
+                      },
+                      "Heating": {
+                        "datatype": "int8",
+                        "deprecation": "v4.1 replaced with HeatingCooling",
+                        "description": "Seat cooling / heating. 0 = off. -100 = max cold. +100 = max heat.",
+                        "max": 100,
+                        "min": -100,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "HeatingCooling": {
+                        "datatype": "int8",
+                        "description": "Heating or Cooling requsted for the Item. -100 = Maximum cooling, 0 = Heating/cooling deactivated, 100 = Maximum heating.",
+                        "max": 100,
+                        "min": -100,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "Height": {
+                        "datatype": "uint16",
+                        "description": "Seat position on vehicle z-axis. Position is relative within available movable range of the seating. 0 = Lowermost position supported.",
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "mm"
+                      },
+                      "IsBelted": {
+                        "datatype": "boolean",
+                        "dbc2vss": {
+                          "interval_ms": 1000,
+                          "signal": "VCFRONT_driverBuckleStatus",
+                          "transform": {
+                            "mapping": [
+                              {
+                                "from": "BUCKLED",
+                                "to": true
+                              },
+                              {
+                                "from": "UNBUCKLED",
+                                "to": false
+                              }
+                            ]
+                          }
+                        },
+                        "description": "Is the belt engaged.",
+                        "type": "sensor"
+                      },
+                      "IsOccupied": {
+                        "datatype": "boolean",
+                        "description": "Does the seat have a passenger in it.",
+                        "type": "sensor"
+                      },
+                      "Massage": {
+                        "datatype": "uint8",
+                        "description": "Seat massage level. 0 = off. 100 = max massage.",
+                        "max": 100,
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "Occupant": {
+                        "children": {
+                          "Identifier": {
+                            "children": {
+                              "Issuer": {
+                                "datatype": "string",
+                                "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                                "description": "Unique Issuer for the authentication of the occupant e.g. https://accounts.funcorp.com.",
+                                "type": "sensor"
+                              },
+                              "Subject": {
+                                "datatype": "string",
+                                "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                                "description": "Subject for the authentication of the occupant e.g. UserID 7331677.",
+                                "type": "sensor"
+                              }
+                            },
+                            "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                            "description": "Identifier attributes based on OAuth 2.0.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Occupant data.",
+                        "type": "branch"
+                      },
+                      "Position": {
+                        "datatype": "uint16",
+                        "description": "Seat position on vehicle x-axis. Position is relative to the frontmost position supported by the seat. 0 = Frontmost position supported.",
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "mm"
+                      },
+                      "SeatBeltHeight": {
+                        "datatype": "uint16",
+                        "description": "Seat belt position on vehicle z-axis. Position is relative within available movable range of the seat belt. 0 = Lowermost position supported.",
+                        "type": "actuator",
+                        "unit": "mm"
+                      },
+                      "Seating": {
+                        "children": {
+                          "Length": {
+                            "datatype": "uint16",
+                            "description": "Length adjustment of seating. 0 = Adjustable part of seating in rearmost position (Shortest length of seating).",
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "mm"
+                          }
+                        },
+                        "comment": "Seating is here considered as the part of the seat that supports the thighs. Additional cushions (if any) for support of lower legs is not covered by this branch.",
+                        "description": "Describes signals related to the seat bottom of the seat.",
+                        "type": "branch"
+                      },
+                      "Switch": {
+                        "children": {
+                          "Backrest": {
+                            "children": {
+                              "IsReclineBackwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Backrest recline backward switch engaged (SingleSeat.Backrest.Recline).",
+                                "type": "actuator"
+                              },
+                              "IsReclineForwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Backrest recline forward switch engaged (SingleSeat.Backrest.Recline).",
+                                "type": "actuator"
+                              },
+                              "Lumbar": {
+                                "children": {
+                                  "IsDownEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Lumbar down switch engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsLessSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for less lumbar support engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsMoreSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for more lumbar support engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsUpEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Lumbar up switch engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  }
+                                },
+                                "description": "Switches for SingleSeat.Backrest.Lumbar.",
+                                "type": "branch"
+                              },
+                              "SideBolster": {
+                                "children": {
+                                  "IsLessSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for less side bolster support engaged (SingleSeat.Backrest.SideBolster.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsMoreSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for more side bolster support engaged (SingleSeat.Backrest.SideBolster.Support).",
+                                    "type": "actuator"
+                                  }
+                                },
+                                "description": "Switches for SingleSeat.Backrest.SideBolster.",
+                                "type": "branch"
+                              }
+                            },
+                            "description": "Describes switches related to the backrest of the seat.",
+                            "type": "branch"
+                          },
+                          "Headrest": {
+                            "children": {
+                              "IsBackwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest backward switch engaged (SingleSeat.Headrest.Angle).",
+                                "type": "actuator"
+                              },
+                              "IsDownEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest down switch engaged (SingleSeat.Headrest.Height).",
+                                "type": "actuator"
+                              },
+                              "IsForwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest forward switch engaged (SingleSeat.Headrest.Angle).",
+                                "type": "actuator"
+                              },
+                              "IsUpEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest up switch engaged (SingleSeat.Headrest.Height).",
+                                "type": "actuator"
+                              }
+                            },
+                            "description": "Switches for SingleSeat.Headrest.",
+                            "type": "branch"
+                          },
+                          "IsBackwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat backward switch engaged (SingleSeat.Position).",
+                            "type": "actuator"
+                          },
+                          "IsCoolerEngaged": {
+                            "datatype": "boolean",
+                            "description": "Cooler switch for Seat heater (SingleSeat.Heating).",
+                            "type": "actuator"
+                          },
+                          "IsDownEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat down switch engaged (SingleSeat.Height).",
+                            "type": "actuator"
+                          },
+                          "IsForwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat forward switch engaged (SingleSeat.Position).",
+                            "type": "actuator"
+                          },
+                          "IsTiltBackwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Tilt backward switch engaged (SingleSeat.Tilt).",
+                            "type": "actuator"
+                          },
+                          "IsTiltForwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Tilt forward switch engaged (SingleSeat.Tilt).",
+                            "type": "actuator"
+                          },
+                          "IsUpEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat up switch engaged (SingleSeat.Height).",
+                            "type": "actuator"
+                          },
+                          "IsWarmerEngaged": {
+                            "datatype": "boolean",
+                            "description": "Warmer switch for Seat heater (SingleSeat.Heating).",
+                            "type": "actuator"
+                          },
+                          "Massage": {
+                            "children": {
+                              "IsDecreaseEngaged": {
+                                "datatype": "boolean",
+                                "description": "Decrease massage level switch engaged (SingleSeat.Massage).",
+                                "type": "actuator"
+                              },
+                              "IsIncreaseEngaged": {
+                                "datatype": "boolean",
+                                "description": "Increase massage level switch engaged (SingleSeat.Massage).",
+                                "type": "actuator"
+                              }
+                            },
+                            "description": "Switches for SingleSeat.Massage.",
+                            "type": "branch"
+                          },
+                          "Seating": {
+                            "children": {
+                              "IsBackwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Is switch to decrease seating length engaged (SingleSeat.Seating.Length).",
+                                "type": "actuator"
+                              },
+                              "IsForwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Is switch to increase seating length engaged (SingleSeat.Seating.Length).",
+                                "type": "actuator"
+                              }
+                            },
+                            "description": "Describes switches related to the seating of the seat.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Seat switch signals",
+                        "type": "branch"
+                      },
+                      "Tilt": {
+                        "comment": "In VSS it is assumed that tilting a seat affects both seating (seat bottom) and backrest, i.e. the angle between seating and backrest will not be affected when changing Tilt.",
+                        "datatype": "float",
+                        "description": "Tilting of seat (seating and backrest) relative to vehicle x-axis. 0 = seat bottom is flat, seat bottom and vehicle x-axis are parallel. Positive degrees = seat tilted backwards, seat x-axis tilted upward, seat z-axis is tilted backward.",
+                        "type": "actuator",
+                        "unit": "degrees"
+                      }
+                    },
+                    "description": "All seats.",
+                    "type": "branch"
+                  },
+                  "Middle": {
+                    "children": {
+                      "Airbag": {
+                        "children": {
+                          "IsDeployed": {
+                            "datatype": "boolean",
+                            "description": "Airbag deployment status. True = Airbag deployed. False = Airbag not deployed.",
+                            "type": "sensor"
+                          }
+                        },
+                        "description": "Airbag signals.",
+                        "type": "branch"
+                      },
+                      "Backrest": {
+                        "children": {
+                          "Lumbar": {
+                            "children": {
+                              "Height": {
+                                "datatype": "uint8",
+                                "description": "Height of lumbar support. Position is relative within available movable range of the lumbar support. 0 = Lowermost position supported.",
+                                "min": 0,
+                                "type": "actuator",
+                                "unit": "mm"
+                              },
+                              "Support": {
+                                "datatype": "float",
+                                "description": "Lumbar support (in/out position). 0 = Innermost position. 100 = Outermost position.",
+                                "max": 100,
+                                "min": 0,
+                                "type": "actuator",
+                                "unit": "percent"
+                              }
+                            },
+                            "description": "Adjustable lumbar support mechanisms in seats allow the user to change the seat back shape.",
+                            "type": "branch"
+                          },
+                          "Recline": {
+                            "comment": "Seat z-axis depends on seat tilt. This means that movement of backrest due to seat tilting will not affect Backrest.Recline as long as the angle between Seating and Backrest are constant. Absolute recline relative to vehicle z-axis can be calculated as Tilt + Backrest.Recline.",
+                            "datatype": "float",
+                            "description": "Backrest recline compared to seat z-axis (seat vertical axis). 0 degrees = Upright/Vertical backrest. Negative degrees for forward recline. Positive degrees for backward recline.",
+                            "type": "actuator",
+                            "unit": "degrees"
+                          },
+                          "SideBolster": {
+                            "children": {
+                              "Support": {
+                                "datatype": "float",
+                                "description": "Side bolster support. 0 = Minimum support (widest side bolster setting). 100 = Maximum support.",
+                                "max": 100,
+                                "min": 0,
+                                "type": "actuator",
+                                "unit": "percent"
+                              }
+                            },
+                            "description": "Backrest side bolster (lumbar side support) settings.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Describes signals related to the backrest of the seat.",
+                        "type": "branch"
+                      },
+                      "Headrest": {
+                        "children": {
+                          "Angle": {
+                            "datatype": "float",
+                            "description": "Headrest angle, relative to backrest, 0 degrees if parallel to backrest, Positive degrees = tilted forward.",
+                            "type": "actuator",
+                            "unit": "degrees"
+                          },
+                          "Height": {
+                            "datatype": "uint8",
+                            "description": "Position of headrest relative to movable range of the head rest. 0 = Bottommost position supported.",
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "mm"
+                          }
+                        },
+                        "description": "Headrest settings.",
+                        "type": "branch"
+                      },
+                      "Heating": {
+                        "datatype": "int8",
+                        "deprecation": "v4.1 replaced with HeatingCooling",
+                        "description": "Seat cooling / heating. 0 = off. -100 = max cold. +100 = max heat.",
+                        "max": 100,
+                        "min": -100,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "HeatingCooling": {
+                        "datatype": "int8",
+                        "description": "Heating or Cooling requsted for the Item. -100 = Maximum cooling, 0 = Heating/cooling deactivated, 100 = Maximum heating.",
+                        "max": 100,
+                        "min": -100,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "Height": {
+                        "datatype": "uint16",
+                        "description": "Seat position on vehicle z-axis. Position is relative within available movable range of the seating. 0 = Lowermost position supported.",
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "mm"
+                      },
+                      "IsBelted": {
+                        "datatype": "boolean",
+                        "description": "Is the belt engaged.",
+                        "type": "sensor"
+                      },
+                      "IsOccupied": {
+                        "datatype": "boolean",
+                        "description": "Does the seat have a passenger in it.",
+                        "type": "sensor"
+                      },
+                      "Massage": {
+                        "datatype": "uint8",
+                        "description": "Seat massage level. 0 = off. 100 = max massage.",
+                        "max": 100,
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "Occupant": {
+                        "children": {
+                          "Identifier": {
+                            "children": {
+                              "Issuer": {
+                                "datatype": "string",
+                                "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                                "description": "Unique Issuer for the authentication of the occupant e.g. https://accounts.funcorp.com.",
+                                "type": "sensor"
+                              },
+                              "Subject": {
+                                "datatype": "string",
+                                "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                                "description": "Subject for the authentication of the occupant e.g. UserID 7331677.",
+                                "type": "sensor"
+                              }
+                            },
+                            "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                            "description": "Identifier attributes based on OAuth 2.0.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Occupant data.",
+                        "type": "branch"
+                      },
+                      "Position": {
+                        "datatype": "uint16",
+                        "description": "Seat position on vehicle x-axis. Position is relative to the frontmost position supported by the seat. 0 = Frontmost position supported.",
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "mm"
+                      },
+                      "SeatBeltHeight": {
+                        "datatype": "uint16",
+                        "description": "Seat belt position on vehicle z-axis. Position is relative within available movable range of the seat belt. 0 = Lowermost position supported.",
+                        "type": "actuator",
+                        "unit": "mm"
+                      },
+                      "Seating": {
+                        "children": {
+                          "Length": {
+                            "datatype": "uint16",
+                            "description": "Length adjustment of seating. 0 = Adjustable part of seating in rearmost position (Shortest length of seating).",
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "mm"
+                          }
+                        },
+                        "comment": "Seating is here considered as the part of the seat that supports the thighs. Additional cushions (if any) for support of lower legs is not covered by this branch.",
+                        "description": "Describes signals related to the seat bottom of the seat.",
+                        "type": "branch"
+                      },
+                      "Switch": {
+                        "children": {
+                          "Backrest": {
+                            "children": {
+                              "IsReclineBackwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Backrest recline backward switch engaged (SingleSeat.Backrest.Recline).",
+                                "type": "actuator"
+                              },
+                              "IsReclineForwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Backrest recline forward switch engaged (SingleSeat.Backrest.Recline).",
+                                "type": "actuator"
+                              },
+                              "Lumbar": {
+                                "children": {
+                                  "IsDownEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Lumbar down switch engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsLessSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for less lumbar support engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsMoreSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for more lumbar support engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsUpEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Lumbar up switch engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  }
+                                },
+                                "description": "Switches for SingleSeat.Backrest.Lumbar.",
+                                "type": "branch"
+                              },
+                              "SideBolster": {
+                                "children": {
+                                  "IsLessSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for less side bolster support engaged (SingleSeat.Backrest.SideBolster.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsMoreSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for more side bolster support engaged (SingleSeat.Backrest.SideBolster.Support).",
+                                    "type": "actuator"
+                                  }
+                                },
+                                "description": "Switches for SingleSeat.Backrest.SideBolster.",
+                                "type": "branch"
+                              }
+                            },
+                            "description": "Describes switches related to the backrest of the seat.",
+                            "type": "branch"
+                          },
+                          "Headrest": {
+                            "children": {
+                              "IsBackwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest backward switch engaged (SingleSeat.Headrest.Angle).",
+                                "type": "actuator"
+                              },
+                              "IsDownEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest down switch engaged (SingleSeat.Headrest.Height).",
+                                "type": "actuator"
+                              },
+                              "IsForwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest forward switch engaged (SingleSeat.Headrest.Angle).",
+                                "type": "actuator"
+                              },
+                              "IsUpEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest up switch engaged (SingleSeat.Headrest.Height).",
+                                "type": "actuator"
+                              }
+                            },
+                            "description": "Switches for SingleSeat.Headrest.",
+                            "type": "branch"
+                          },
+                          "IsBackwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat backward switch engaged (SingleSeat.Position).",
+                            "type": "actuator"
+                          },
+                          "IsCoolerEngaged": {
+                            "datatype": "boolean",
+                            "description": "Cooler switch for Seat heater (SingleSeat.Heating).",
+                            "type": "actuator"
+                          },
+                          "IsDownEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat down switch engaged (SingleSeat.Height).",
+                            "type": "actuator"
+                          },
+                          "IsForwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat forward switch engaged (SingleSeat.Position).",
+                            "type": "actuator"
+                          },
+                          "IsTiltBackwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Tilt backward switch engaged (SingleSeat.Tilt).",
+                            "type": "actuator"
+                          },
+                          "IsTiltForwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Tilt forward switch engaged (SingleSeat.Tilt).",
+                            "type": "actuator"
+                          },
+                          "IsUpEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat up switch engaged (SingleSeat.Height).",
+                            "type": "actuator"
+                          },
+                          "IsWarmerEngaged": {
+                            "datatype": "boolean",
+                            "description": "Warmer switch for Seat heater (SingleSeat.Heating).",
+                            "type": "actuator"
+                          },
+                          "Massage": {
+                            "children": {
+                              "IsDecreaseEngaged": {
+                                "datatype": "boolean",
+                                "description": "Decrease massage level switch engaged (SingleSeat.Massage).",
+                                "type": "actuator"
+                              },
+                              "IsIncreaseEngaged": {
+                                "datatype": "boolean",
+                                "description": "Increase massage level switch engaged (SingleSeat.Massage).",
+                                "type": "actuator"
+                              }
+                            },
+                            "description": "Switches for SingleSeat.Massage.",
+                            "type": "branch"
+                          },
+                          "Seating": {
+                            "children": {
+                              "IsBackwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Is switch to decrease seating length engaged (SingleSeat.Seating.Length).",
+                                "type": "actuator"
+                              },
+                              "IsForwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Is switch to increase seating length engaged (SingleSeat.Seating.Length).",
+                                "type": "actuator"
+                              }
+                            },
+                            "description": "Describes switches related to the seating of the seat.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Seat switch signals",
+                        "type": "branch"
+                      },
+                      "Tilt": {
+                        "comment": "In VSS it is assumed that tilting a seat affects both seating (seat bottom) and backrest, i.e. the angle between seating and backrest will not be affected when changing Tilt.",
+                        "datatype": "float",
+                        "description": "Tilting of seat (seating and backrest) relative to vehicle x-axis. 0 = seat bottom is flat, seat bottom and vehicle x-axis are parallel. Positive degrees = seat tilted backwards, seat x-axis tilted upward, seat z-axis is tilted backward.",
+                        "type": "actuator",
+                        "unit": "degrees"
+                      }
+                    },
+                    "description": "All seats.",
+                    "type": "branch"
+                  },
+                  "PassengerSide": {
+                    "children": {
+                      "Airbag": {
+                        "children": {
+                          "IsDeployed": {
+                            "datatype": "boolean",
+                            "description": "Airbag deployment status. True = Airbag deployed. False = Airbag not deployed.",
+                            "type": "sensor"
+                          }
+                        },
+                        "description": "Airbag signals.",
+                        "type": "branch"
+                      },
+                      "Backrest": {
+                        "children": {
+                          "Lumbar": {
+                            "children": {
+                              "Height": {
+                                "datatype": "uint8",
+                                "description": "Height of lumbar support. Position is relative within available movable range of the lumbar support. 0 = Lowermost position supported.",
+                                "min": 0,
+                                "type": "actuator",
+                                "unit": "mm"
+                              },
+                              "Support": {
+                                "datatype": "float",
+                                "description": "Lumbar support (in/out position). 0 = Innermost position. 100 = Outermost position.",
+                                "max": 100,
+                                "min": 0,
+                                "type": "actuator",
+                                "unit": "percent"
+                              }
+                            },
+                            "description": "Adjustable lumbar support mechanisms in seats allow the user to change the seat back shape.",
+                            "type": "branch"
+                          },
+                          "Recline": {
+                            "comment": "Seat z-axis depends on seat tilt. This means that movement of backrest due to seat tilting will not affect Backrest.Recline as long as the angle between Seating and Backrest are constant. Absolute recline relative to vehicle z-axis can be calculated as Tilt + Backrest.Recline.",
+                            "datatype": "float",
+                            "description": "Backrest recline compared to seat z-axis (seat vertical axis). 0 degrees = Upright/Vertical backrest. Negative degrees for forward recline. Positive degrees for backward recline.",
+                            "type": "actuator",
+                            "unit": "degrees"
+                          },
+                          "SideBolster": {
+                            "children": {
+                              "Support": {
+                                "datatype": "float",
+                                "description": "Side bolster support. 0 = Minimum support (widest side bolster setting). 100 = Maximum support.",
+                                "max": 100,
+                                "min": 0,
+                                "type": "actuator",
+                                "unit": "percent"
+                              }
+                            },
+                            "description": "Backrest side bolster (lumbar side support) settings.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Describes signals related to the backrest of the seat.",
+                        "type": "branch"
+                      },
+                      "Headrest": {
+                        "children": {
+                          "Angle": {
+                            "datatype": "float",
+                            "description": "Headrest angle, relative to backrest, 0 degrees if parallel to backrest, Positive degrees = tilted forward.",
+                            "type": "actuator",
+                            "unit": "degrees"
+                          },
+                          "Height": {
+                            "datatype": "uint8",
+                            "description": "Position of headrest relative to movable range of the head rest. 0 = Bottommost position supported.",
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "mm"
+                          }
+                        },
+                        "description": "Headrest settings.",
+                        "type": "branch"
+                      },
+                      "Heating": {
+                        "datatype": "int8",
+                        "deprecation": "v4.1 replaced with HeatingCooling",
+                        "description": "Seat cooling / heating. 0 = off. -100 = max cold. +100 = max heat.",
+                        "max": 100,
+                        "min": -100,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "HeatingCooling": {
+                        "datatype": "int8",
+                        "description": "Heating or Cooling requsted for the Item. -100 = Maximum cooling, 0 = Heating/cooling deactivated, 100 = Maximum heating.",
+                        "max": 100,
+                        "min": -100,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "Height": {
+                        "datatype": "uint16",
+                        "description": "Seat position on vehicle z-axis. Position is relative within available movable range of the seating. 0 = Lowermost position supported.",
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "mm"
+                      },
+                      "IsBelted": {
+                        "datatype": "boolean",
+                        "description": "Is the belt engaged.",
+                        "type": "sensor"
+                      },
+                      "IsOccupied": {
+                        "datatype": "boolean",
+                        "description": "Does the seat have a passenger in it.",
+                        "type": "sensor"
+                      },
+                      "Massage": {
+                        "datatype": "uint8",
+                        "description": "Seat massage level. 0 = off. 100 = max massage.",
+                        "max": 100,
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "Occupant": {
+                        "children": {
+                          "Identifier": {
+                            "children": {
+                              "Issuer": {
+                                "datatype": "string",
+                                "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                                "description": "Unique Issuer for the authentication of the occupant e.g. https://accounts.funcorp.com.",
+                                "type": "sensor"
+                              },
+                              "Subject": {
+                                "datatype": "string",
+                                "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                                "description": "Subject for the authentication of the occupant e.g. UserID 7331677.",
+                                "type": "sensor"
+                              }
+                            },
+                            "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                            "description": "Identifier attributes based on OAuth 2.0.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Occupant data.",
+                        "type": "branch"
+                      },
+                      "Position": {
+                        "datatype": "uint16",
+                        "description": "Seat position on vehicle x-axis. Position is relative to the frontmost position supported by the seat. 0 = Frontmost position supported.",
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "mm"
+                      },
+                      "SeatBeltHeight": {
+                        "datatype": "uint16",
+                        "description": "Seat belt position on vehicle z-axis. Position is relative within available movable range of the seat belt. 0 = Lowermost position supported.",
+                        "type": "actuator",
+                        "unit": "mm"
+                      },
+                      "Seating": {
+                        "children": {
+                          "Length": {
+                            "datatype": "uint16",
+                            "description": "Length adjustment of seating. 0 = Adjustable part of seating in rearmost position (Shortest length of seating).",
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "mm"
+                          }
+                        },
+                        "comment": "Seating is here considered as the part of the seat that supports the thighs. Additional cushions (if any) for support of lower legs is not covered by this branch.",
+                        "description": "Describes signals related to the seat bottom of the seat.",
+                        "type": "branch"
+                      },
+                      "Switch": {
+                        "children": {
+                          "Backrest": {
+                            "children": {
+                              "IsReclineBackwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Backrest recline backward switch engaged (SingleSeat.Backrest.Recline).",
+                                "type": "actuator"
+                              },
+                              "IsReclineForwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Backrest recline forward switch engaged (SingleSeat.Backrest.Recline).",
+                                "type": "actuator"
+                              },
+                              "Lumbar": {
+                                "children": {
+                                  "IsDownEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Lumbar down switch engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsLessSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for less lumbar support engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsMoreSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for more lumbar support engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsUpEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Lumbar up switch engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  }
+                                },
+                                "description": "Switches for SingleSeat.Backrest.Lumbar.",
+                                "type": "branch"
+                              },
+                              "SideBolster": {
+                                "children": {
+                                  "IsLessSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for less side bolster support engaged (SingleSeat.Backrest.SideBolster.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsMoreSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for more side bolster support engaged (SingleSeat.Backrest.SideBolster.Support).",
+                                    "type": "actuator"
+                                  }
+                                },
+                                "description": "Switches for SingleSeat.Backrest.SideBolster.",
+                                "type": "branch"
+                              }
+                            },
+                            "description": "Describes switches related to the backrest of the seat.",
+                            "type": "branch"
+                          },
+                          "Headrest": {
+                            "children": {
+                              "IsBackwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest backward switch engaged (SingleSeat.Headrest.Angle).",
+                                "type": "actuator"
+                              },
+                              "IsDownEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest down switch engaged (SingleSeat.Headrest.Height).",
+                                "type": "actuator"
+                              },
+                              "IsForwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest forward switch engaged (SingleSeat.Headrest.Angle).",
+                                "type": "actuator"
+                              },
+                              "IsUpEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest up switch engaged (SingleSeat.Headrest.Height).",
+                                "type": "actuator"
+                              }
+                            },
+                            "description": "Switches for SingleSeat.Headrest.",
+                            "type": "branch"
+                          },
+                          "IsBackwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat backward switch engaged (SingleSeat.Position).",
+                            "type": "actuator"
+                          },
+                          "IsCoolerEngaged": {
+                            "datatype": "boolean",
+                            "description": "Cooler switch for Seat heater (SingleSeat.Heating).",
+                            "type": "actuator"
+                          },
+                          "IsDownEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat down switch engaged (SingleSeat.Height).",
+                            "type": "actuator"
+                          },
+                          "IsForwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat forward switch engaged (SingleSeat.Position).",
+                            "type": "actuator"
+                          },
+                          "IsTiltBackwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Tilt backward switch engaged (SingleSeat.Tilt).",
+                            "type": "actuator"
+                          },
+                          "IsTiltForwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Tilt forward switch engaged (SingleSeat.Tilt).",
+                            "type": "actuator"
+                          },
+                          "IsUpEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat up switch engaged (SingleSeat.Height).",
+                            "type": "actuator"
+                          },
+                          "IsWarmerEngaged": {
+                            "datatype": "boolean",
+                            "description": "Warmer switch for Seat heater (SingleSeat.Heating).",
+                            "type": "actuator"
+                          },
+                          "Massage": {
+                            "children": {
+                              "IsDecreaseEngaged": {
+                                "datatype": "boolean",
+                                "description": "Decrease massage level switch engaged (SingleSeat.Massage).",
+                                "type": "actuator"
+                              },
+                              "IsIncreaseEngaged": {
+                                "datatype": "boolean",
+                                "description": "Increase massage level switch engaged (SingleSeat.Massage).",
+                                "type": "actuator"
+                              }
+                            },
+                            "description": "Switches for SingleSeat.Massage.",
+                            "type": "branch"
+                          },
+                          "Seating": {
+                            "children": {
+                              "IsBackwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Is switch to decrease seating length engaged (SingleSeat.Seating.Length).",
+                                "type": "actuator"
+                              },
+                              "IsForwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Is switch to increase seating length engaged (SingleSeat.Seating.Length).",
+                                "type": "actuator"
+                              }
+                            },
+                            "description": "Describes switches related to the seating of the seat.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Seat switch signals",
+                        "type": "branch"
+                      },
+                      "Tilt": {
+                        "comment": "In VSS it is assumed that tilting a seat affects both seating (seat bottom) and backrest, i.e. the angle between seating and backrest will not be affected when changing Tilt.",
+                        "datatype": "float",
+                        "description": "Tilting of seat (seating and backrest) relative to vehicle x-axis. 0 = seat bottom is flat, seat bottom and vehicle x-axis are parallel. Positive degrees = seat tilted backwards, seat x-axis tilted upward, seat z-axis is tilted backward.",
+                        "type": "actuator",
+                        "unit": "degrees"
+                      }
+                    },
+                    "description": "All seats.",
+                    "type": "branch"
+                  }
+                },
+                "description": "All seats.",
+                "type": "branch"
+              },
+              "Row2": {
+                "children": {
+                  "DriverSide": {
+                    "children": {
+                      "Airbag": {
+                        "children": {
+                          "IsDeployed": {
+                            "datatype": "boolean",
+                            "description": "Airbag deployment status. True = Airbag deployed. False = Airbag not deployed.",
+                            "type": "sensor"
+                          }
+                        },
+                        "description": "Airbag signals.",
+                        "type": "branch"
+                      },
+                      "Backrest": {
+                        "children": {
+                          "Lumbar": {
+                            "children": {
+                              "Height": {
+                                "datatype": "uint8",
+                                "description": "Height of lumbar support. Position is relative within available movable range of the lumbar support. 0 = Lowermost position supported.",
+                                "min": 0,
+                                "type": "actuator",
+                                "unit": "mm"
+                              },
+                              "Support": {
+                                "datatype": "float",
+                                "description": "Lumbar support (in/out position). 0 = Innermost position. 100 = Outermost position.",
+                                "max": 100,
+                                "min": 0,
+                                "type": "actuator",
+                                "unit": "percent"
+                              }
+                            },
+                            "description": "Adjustable lumbar support mechanisms in seats allow the user to change the seat back shape.",
+                            "type": "branch"
+                          },
+                          "Recline": {
+                            "comment": "Seat z-axis depends on seat tilt. This means that movement of backrest due to seat tilting will not affect Backrest.Recline as long as the angle between Seating and Backrest are constant. Absolute recline relative to vehicle z-axis can be calculated as Tilt + Backrest.Recline.",
+                            "datatype": "float",
+                            "description": "Backrest recline compared to seat z-axis (seat vertical axis). 0 degrees = Upright/Vertical backrest. Negative degrees for forward recline. Positive degrees for backward recline.",
+                            "type": "actuator",
+                            "unit": "degrees"
+                          },
+                          "SideBolster": {
+                            "children": {
+                              "Support": {
+                                "datatype": "float",
+                                "description": "Side bolster support. 0 = Minimum support (widest side bolster setting). 100 = Maximum support.",
+                                "max": 100,
+                                "min": 0,
+                                "type": "actuator",
+                                "unit": "percent"
+                              }
+                            },
+                            "description": "Backrest side bolster (lumbar side support) settings.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Describes signals related to the backrest of the seat.",
+                        "type": "branch"
+                      },
+                      "Headrest": {
+                        "children": {
+                          "Angle": {
+                            "datatype": "float",
+                            "description": "Headrest angle, relative to backrest, 0 degrees if parallel to backrest, Positive degrees = tilted forward.",
+                            "type": "actuator",
+                            "unit": "degrees"
+                          },
+                          "Height": {
+                            "datatype": "uint8",
+                            "description": "Position of headrest relative to movable range of the head rest. 0 = Bottommost position supported.",
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "mm"
+                          }
+                        },
+                        "description": "Headrest settings.",
+                        "type": "branch"
+                      },
+                      "Heating": {
+                        "datatype": "int8",
+                        "deprecation": "v4.1 replaced with HeatingCooling",
+                        "description": "Seat cooling / heating. 0 = off. -100 = max cold. +100 = max heat.",
+                        "max": 100,
+                        "min": -100,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "HeatingCooling": {
+                        "datatype": "int8",
+                        "description": "Heating or Cooling requsted for the Item. -100 = Maximum cooling, 0 = Heating/cooling deactivated, 100 = Maximum heating.",
+                        "max": 100,
+                        "min": -100,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "Height": {
+                        "datatype": "uint16",
+                        "description": "Seat position on vehicle z-axis. Position is relative within available movable range of the seating. 0 = Lowermost position supported.",
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "mm"
+                      },
+                      "IsBelted": {
+                        "datatype": "boolean",
+                        "description": "Is the belt engaged.",
+                        "type": "sensor"
+                      },
+                      "IsOccupied": {
+                        "datatype": "boolean",
+                        "description": "Does the seat have a passenger in it.",
+                        "type": "sensor"
+                      },
+                      "Massage": {
+                        "datatype": "uint8",
+                        "description": "Seat massage level. 0 = off. 100 = max massage.",
+                        "max": 100,
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "Occupant": {
+                        "children": {
+                          "Identifier": {
+                            "children": {
+                              "Issuer": {
+                                "datatype": "string",
+                                "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                                "description": "Unique Issuer for the authentication of the occupant e.g. https://accounts.funcorp.com.",
+                                "type": "sensor"
+                              },
+                              "Subject": {
+                                "datatype": "string",
+                                "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                                "description": "Subject for the authentication of the occupant e.g. UserID 7331677.",
+                                "type": "sensor"
+                              }
+                            },
+                            "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                            "description": "Identifier attributes based on OAuth 2.0.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Occupant data.",
+                        "type": "branch"
+                      },
+                      "Position": {
+                        "datatype": "uint16",
+                        "description": "Seat position on vehicle x-axis. Position is relative to the frontmost position supported by the seat. 0 = Frontmost position supported.",
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "mm"
+                      },
+                      "SeatBeltHeight": {
+                        "datatype": "uint16",
+                        "description": "Seat belt position on vehicle z-axis. Position is relative within available movable range of the seat belt. 0 = Lowermost position supported.",
+                        "type": "actuator",
+                        "unit": "mm"
+                      },
+                      "Seating": {
+                        "children": {
+                          "Length": {
+                            "datatype": "uint16",
+                            "description": "Length adjustment of seating. 0 = Adjustable part of seating in rearmost position (Shortest length of seating).",
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "mm"
+                          }
+                        },
+                        "comment": "Seating is here considered as the part of the seat that supports the thighs. Additional cushions (if any) for support of lower legs is not covered by this branch.",
+                        "description": "Describes signals related to the seat bottom of the seat.",
+                        "type": "branch"
+                      },
+                      "Switch": {
+                        "children": {
+                          "Backrest": {
+                            "children": {
+                              "IsReclineBackwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Backrest recline backward switch engaged (SingleSeat.Backrest.Recline).",
+                                "type": "actuator"
+                              },
+                              "IsReclineForwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Backrest recline forward switch engaged (SingleSeat.Backrest.Recline).",
+                                "type": "actuator"
+                              },
+                              "Lumbar": {
+                                "children": {
+                                  "IsDownEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Lumbar down switch engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsLessSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for less lumbar support engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsMoreSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for more lumbar support engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsUpEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Lumbar up switch engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  }
+                                },
+                                "description": "Switches for SingleSeat.Backrest.Lumbar.",
+                                "type": "branch"
+                              },
+                              "SideBolster": {
+                                "children": {
+                                  "IsLessSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for less side bolster support engaged (SingleSeat.Backrest.SideBolster.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsMoreSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for more side bolster support engaged (SingleSeat.Backrest.SideBolster.Support).",
+                                    "type": "actuator"
+                                  }
+                                },
+                                "description": "Switches for SingleSeat.Backrest.SideBolster.",
+                                "type": "branch"
+                              }
+                            },
+                            "description": "Describes switches related to the backrest of the seat.",
+                            "type": "branch"
+                          },
+                          "Headrest": {
+                            "children": {
+                              "IsBackwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest backward switch engaged (SingleSeat.Headrest.Angle).",
+                                "type": "actuator"
+                              },
+                              "IsDownEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest down switch engaged (SingleSeat.Headrest.Height).",
+                                "type": "actuator"
+                              },
+                              "IsForwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest forward switch engaged (SingleSeat.Headrest.Angle).",
+                                "type": "actuator"
+                              },
+                              "IsUpEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest up switch engaged (SingleSeat.Headrest.Height).",
+                                "type": "actuator"
+                              }
+                            },
+                            "description": "Switches for SingleSeat.Headrest.",
+                            "type": "branch"
+                          },
+                          "IsBackwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat backward switch engaged (SingleSeat.Position).",
+                            "type": "actuator"
+                          },
+                          "IsCoolerEngaged": {
+                            "datatype": "boolean",
+                            "description": "Cooler switch for Seat heater (SingleSeat.Heating).",
+                            "type": "actuator"
+                          },
+                          "IsDownEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat down switch engaged (SingleSeat.Height).",
+                            "type": "actuator"
+                          },
+                          "IsForwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat forward switch engaged (SingleSeat.Position).",
+                            "type": "actuator"
+                          },
+                          "IsTiltBackwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Tilt backward switch engaged (SingleSeat.Tilt).",
+                            "type": "actuator"
+                          },
+                          "IsTiltForwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Tilt forward switch engaged (SingleSeat.Tilt).",
+                            "type": "actuator"
+                          },
+                          "IsUpEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat up switch engaged (SingleSeat.Height).",
+                            "type": "actuator"
+                          },
+                          "IsWarmerEngaged": {
+                            "datatype": "boolean",
+                            "description": "Warmer switch for Seat heater (SingleSeat.Heating).",
+                            "type": "actuator"
+                          },
+                          "Massage": {
+                            "children": {
+                              "IsDecreaseEngaged": {
+                                "datatype": "boolean",
+                                "description": "Decrease massage level switch engaged (SingleSeat.Massage).",
+                                "type": "actuator"
+                              },
+                              "IsIncreaseEngaged": {
+                                "datatype": "boolean",
+                                "description": "Increase massage level switch engaged (SingleSeat.Massage).",
+                                "type": "actuator"
+                              }
+                            },
+                            "description": "Switches for SingleSeat.Massage.",
+                            "type": "branch"
+                          },
+                          "Seating": {
+                            "children": {
+                              "IsBackwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Is switch to decrease seating length engaged (SingleSeat.Seating.Length).",
+                                "type": "actuator"
+                              },
+                              "IsForwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Is switch to increase seating length engaged (SingleSeat.Seating.Length).",
+                                "type": "actuator"
+                              }
+                            },
+                            "description": "Describes switches related to the seating of the seat.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Seat switch signals",
+                        "type": "branch"
+                      },
+                      "Tilt": {
+                        "comment": "In VSS it is assumed that tilting a seat affects both seating (seat bottom) and backrest, i.e. the angle between seating and backrest will not be affected when changing Tilt.",
+                        "datatype": "float",
+                        "description": "Tilting of seat (seating and backrest) relative to vehicle x-axis. 0 = seat bottom is flat, seat bottom and vehicle x-axis are parallel. Positive degrees = seat tilted backwards, seat x-axis tilted upward, seat z-axis is tilted backward.",
+                        "type": "actuator",
+                        "unit": "degrees"
+                      }
+                    },
+                    "description": "All seats.",
+                    "type": "branch"
+                  },
+                  "Middle": {
+                    "children": {
+                      "Airbag": {
+                        "children": {
+                          "IsDeployed": {
+                            "datatype": "boolean",
+                            "description": "Airbag deployment status. True = Airbag deployed. False = Airbag not deployed.",
+                            "type": "sensor"
+                          }
+                        },
+                        "description": "Airbag signals.",
+                        "type": "branch"
+                      },
+                      "Backrest": {
+                        "children": {
+                          "Lumbar": {
+                            "children": {
+                              "Height": {
+                                "datatype": "uint8",
+                                "description": "Height of lumbar support. Position is relative within available movable range of the lumbar support. 0 = Lowermost position supported.",
+                                "min": 0,
+                                "type": "actuator",
+                                "unit": "mm"
+                              },
+                              "Support": {
+                                "datatype": "float",
+                                "description": "Lumbar support (in/out position). 0 = Innermost position. 100 = Outermost position.",
+                                "max": 100,
+                                "min": 0,
+                                "type": "actuator",
+                                "unit": "percent"
+                              }
+                            },
+                            "description": "Adjustable lumbar support mechanisms in seats allow the user to change the seat back shape.",
+                            "type": "branch"
+                          },
+                          "Recline": {
+                            "comment": "Seat z-axis depends on seat tilt. This means that movement of backrest due to seat tilting will not affect Backrest.Recline as long as the angle between Seating and Backrest are constant. Absolute recline relative to vehicle z-axis can be calculated as Tilt + Backrest.Recline.",
+                            "datatype": "float",
+                            "description": "Backrest recline compared to seat z-axis (seat vertical axis). 0 degrees = Upright/Vertical backrest. Negative degrees for forward recline. Positive degrees for backward recline.",
+                            "type": "actuator",
+                            "unit": "degrees"
+                          },
+                          "SideBolster": {
+                            "children": {
+                              "Support": {
+                                "datatype": "float",
+                                "description": "Side bolster support. 0 = Minimum support (widest side bolster setting). 100 = Maximum support.",
+                                "max": 100,
+                                "min": 0,
+                                "type": "actuator",
+                                "unit": "percent"
+                              }
+                            },
+                            "description": "Backrest side bolster (lumbar side support) settings.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Describes signals related to the backrest of the seat.",
+                        "type": "branch"
+                      },
+                      "Headrest": {
+                        "children": {
+                          "Angle": {
+                            "datatype": "float",
+                            "description": "Headrest angle, relative to backrest, 0 degrees if parallel to backrest, Positive degrees = tilted forward.",
+                            "type": "actuator",
+                            "unit": "degrees"
+                          },
+                          "Height": {
+                            "datatype": "uint8",
+                            "description": "Position of headrest relative to movable range of the head rest. 0 = Bottommost position supported.",
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "mm"
+                          }
+                        },
+                        "description": "Headrest settings.",
+                        "type": "branch"
+                      },
+                      "Heating": {
+                        "datatype": "int8",
+                        "deprecation": "v4.1 replaced with HeatingCooling",
+                        "description": "Seat cooling / heating. 0 = off. -100 = max cold. +100 = max heat.",
+                        "max": 100,
+                        "min": -100,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "HeatingCooling": {
+                        "datatype": "int8",
+                        "description": "Heating or Cooling requsted for the Item. -100 = Maximum cooling, 0 = Heating/cooling deactivated, 100 = Maximum heating.",
+                        "max": 100,
+                        "min": -100,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "Height": {
+                        "datatype": "uint16",
+                        "description": "Seat position on vehicle z-axis. Position is relative within available movable range of the seating. 0 = Lowermost position supported.",
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "mm"
+                      },
+                      "IsBelted": {
+                        "datatype": "boolean",
+                        "description": "Is the belt engaged.",
+                        "type": "sensor"
+                      },
+                      "IsOccupied": {
+                        "datatype": "boolean",
+                        "description": "Does the seat have a passenger in it.",
+                        "type": "sensor"
+                      },
+                      "Massage": {
+                        "datatype": "uint8",
+                        "description": "Seat massage level. 0 = off. 100 = max massage.",
+                        "max": 100,
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "Occupant": {
+                        "children": {
+                          "Identifier": {
+                            "children": {
+                              "Issuer": {
+                                "datatype": "string",
+                                "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                                "description": "Unique Issuer for the authentication of the occupant e.g. https://accounts.funcorp.com.",
+                                "type": "sensor"
+                              },
+                              "Subject": {
+                                "datatype": "string",
+                                "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                                "description": "Subject for the authentication of the occupant e.g. UserID 7331677.",
+                                "type": "sensor"
+                              }
+                            },
+                            "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                            "description": "Identifier attributes based on OAuth 2.0.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Occupant data.",
+                        "type": "branch"
+                      },
+                      "Position": {
+                        "datatype": "uint16",
+                        "description": "Seat position on vehicle x-axis. Position is relative to the frontmost position supported by the seat. 0 = Frontmost position supported.",
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "mm"
+                      },
+                      "SeatBeltHeight": {
+                        "datatype": "uint16",
+                        "description": "Seat belt position on vehicle z-axis. Position is relative within available movable range of the seat belt. 0 = Lowermost position supported.",
+                        "type": "actuator",
+                        "unit": "mm"
+                      },
+                      "Seating": {
+                        "children": {
+                          "Length": {
+                            "datatype": "uint16",
+                            "description": "Length adjustment of seating. 0 = Adjustable part of seating in rearmost position (Shortest length of seating).",
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "mm"
+                          }
+                        },
+                        "comment": "Seating is here considered as the part of the seat that supports the thighs. Additional cushions (if any) for support of lower legs is not covered by this branch.",
+                        "description": "Describes signals related to the seat bottom of the seat.",
+                        "type": "branch"
+                      },
+                      "Switch": {
+                        "children": {
+                          "Backrest": {
+                            "children": {
+                              "IsReclineBackwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Backrest recline backward switch engaged (SingleSeat.Backrest.Recline).",
+                                "type": "actuator"
+                              },
+                              "IsReclineForwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Backrest recline forward switch engaged (SingleSeat.Backrest.Recline).",
+                                "type": "actuator"
+                              },
+                              "Lumbar": {
+                                "children": {
+                                  "IsDownEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Lumbar down switch engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsLessSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for less lumbar support engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsMoreSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for more lumbar support engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsUpEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Lumbar up switch engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  }
+                                },
+                                "description": "Switches for SingleSeat.Backrest.Lumbar.",
+                                "type": "branch"
+                              },
+                              "SideBolster": {
+                                "children": {
+                                  "IsLessSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for less side bolster support engaged (SingleSeat.Backrest.SideBolster.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsMoreSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for more side bolster support engaged (SingleSeat.Backrest.SideBolster.Support).",
+                                    "type": "actuator"
+                                  }
+                                },
+                                "description": "Switches for SingleSeat.Backrest.SideBolster.",
+                                "type": "branch"
+                              }
+                            },
+                            "description": "Describes switches related to the backrest of the seat.",
+                            "type": "branch"
+                          },
+                          "Headrest": {
+                            "children": {
+                              "IsBackwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest backward switch engaged (SingleSeat.Headrest.Angle).",
+                                "type": "actuator"
+                              },
+                              "IsDownEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest down switch engaged (SingleSeat.Headrest.Height).",
+                                "type": "actuator"
+                              },
+                              "IsForwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest forward switch engaged (SingleSeat.Headrest.Angle).",
+                                "type": "actuator"
+                              },
+                              "IsUpEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest up switch engaged (SingleSeat.Headrest.Height).",
+                                "type": "actuator"
+                              }
+                            },
+                            "description": "Switches for SingleSeat.Headrest.",
+                            "type": "branch"
+                          },
+                          "IsBackwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat backward switch engaged (SingleSeat.Position).",
+                            "type": "actuator"
+                          },
+                          "IsCoolerEngaged": {
+                            "datatype": "boolean",
+                            "description": "Cooler switch for Seat heater (SingleSeat.Heating).",
+                            "type": "actuator"
+                          },
+                          "IsDownEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat down switch engaged (SingleSeat.Height).",
+                            "type": "actuator"
+                          },
+                          "IsForwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat forward switch engaged (SingleSeat.Position).",
+                            "type": "actuator"
+                          },
+                          "IsTiltBackwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Tilt backward switch engaged (SingleSeat.Tilt).",
+                            "type": "actuator"
+                          },
+                          "IsTiltForwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Tilt forward switch engaged (SingleSeat.Tilt).",
+                            "type": "actuator"
+                          },
+                          "IsUpEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat up switch engaged (SingleSeat.Height).",
+                            "type": "actuator"
+                          },
+                          "IsWarmerEngaged": {
+                            "datatype": "boolean",
+                            "description": "Warmer switch for Seat heater (SingleSeat.Heating).",
+                            "type": "actuator"
+                          },
+                          "Massage": {
+                            "children": {
+                              "IsDecreaseEngaged": {
+                                "datatype": "boolean",
+                                "description": "Decrease massage level switch engaged (SingleSeat.Massage).",
+                                "type": "actuator"
+                              },
+                              "IsIncreaseEngaged": {
+                                "datatype": "boolean",
+                                "description": "Increase massage level switch engaged (SingleSeat.Massage).",
+                                "type": "actuator"
+                              }
+                            },
+                            "description": "Switches for SingleSeat.Massage.",
+                            "type": "branch"
+                          },
+                          "Seating": {
+                            "children": {
+                              "IsBackwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Is switch to decrease seating length engaged (SingleSeat.Seating.Length).",
+                                "type": "actuator"
+                              },
+                              "IsForwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Is switch to increase seating length engaged (SingleSeat.Seating.Length).",
+                                "type": "actuator"
+                              }
+                            },
+                            "description": "Describes switches related to the seating of the seat.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Seat switch signals",
+                        "type": "branch"
+                      },
+                      "Tilt": {
+                        "comment": "In VSS it is assumed that tilting a seat affects both seating (seat bottom) and backrest, i.e. the angle between seating and backrest will not be affected when changing Tilt.",
+                        "datatype": "float",
+                        "description": "Tilting of seat (seating and backrest) relative to vehicle x-axis. 0 = seat bottom is flat, seat bottom and vehicle x-axis are parallel. Positive degrees = seat tilted backwards, seat x-axis tilted upward, seat z-axis is tilted backward.",
+                        "type": "actuator",
+                        "unit": "degrees"
+                      }
+                    },
+                    "description": "All seats.",
+                    "type": "branch"
+                  },
+                  "PassengerSide": {
+                    "children": {
+                      "Airbag": {
+                        "children": {
+                          "IsDeployed": {
+                            "datatype": "boolean",
+                            "description": "Airbag deployment status. True = Airbag deployed. False = Airbag not deployed.",
+                            "type": "sensor"
+                          }
+                        },
+                        "description": "Airbag signals.",
+                        "type": "branch"
+                      },
+                      "Backrest": {
+                        "children": {
+                          "Lumbar": {
+                            "children": {
+                              "Height": {
+                                "datatype": "uint8",
+                                "description": "Height of lumbar support. Position is relative within available movable range of the lumbar support. 0 = Lowermost position supported.",
+                                "min": 0,
+                                "type": "actuator",
+                                "unit": "mm"
+                              },
+                              "Support": {
+                                "datatype": "float",
+                                "description": "Lumbar support (in/out position). 0 = Innermost position. 100 = Outermost position.",
+                                "max": 100,
+                                "min": 0,
+                                "type": "actuator",
+                                "unit": "percent"
+                              }
+                            },
+                            "description": "Adjustable lumbar support mechanisms in seats allow the user to change the seat back shape.",
+                            "type": "branch"
+                          },
+                          "Recline": {
+                            "comment": "Seat z-axis depends on seat tilt. This means that movement of backrest due to seat tilting will not affect Backrest.Recline as long as the angle between Seating and Backrest are constant. Absolute recline relative to vehicle z-axis can be calculated as Tilt + Backrest.Recline.",
+                            "datatype": "float",
+                            "description": "Backrest recline compared to seat z-axis (seat vertical axis). 0 degrees = Upright/Vertical backrest. Negative degrees for forward recline. Positive degrees for backward recline.",
+                            "type": "actuator",
+                            "unit": "degrees"
+                          },
+                          "SideBolster": {
+                            "children": {
+                              "Support": {
+                                "datatype": "float",
+                                "description": "Side bolster support. 0 = Minimum support (widest side bolster setting). 100 = Maximum support.",
+                                "max": 100,
+                                "min": 0,
+                                "type": "actuator",
+                                "unit": "percent"
+                              }
+                            },
+                            "description": "Backrest side bolster (lumbar side support) settings.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Describes signals related to the backrest of the seat.",
+                        "type": "branch"
+                      },
+                      "Headrest": {
+                        "children": {
+                          "Angle": {
+                            "datatype": "float",
+                            "description": "Headrest angle, relative to backrest, 0 degrees if parallel to backrest, Positive degrees = tilted forward.",
+                            "type": "actuator",
+                            "unit": "degrees"
+                          },
+                          "Height": {
+                            "datatype": "uint8",
+                            "description": "Position of headrest relative to movable range of the head rest. 0 = Bottommost position supported.",
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "mm"
+                          }
+                        },
+                        "description": "Headrest settings.",
+                        "type": "branch"
+                      },
+                      "Heating": {
+                        "datatype": "int8",
+                        "deprecation": "v4.1 replaced with HeatingCooling",
+                        "description": "Seat cooling / heating. 0 = off. -100 = max cold. +100 = max heat.",
+                        "max": 100,
+                        "min": -100,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "HeatingCooling": {
+                        "datatype": "int8",
+                        "description": "Heating or Cooling requsted for the Item. -100 = Maximum cooling, 0 = Heating/cooling deactivated, 100 = Maximum heating.",
+                        "max": 100,
+                        "min": -100,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "Height": {
+                        "datatype": "uint16",
+                        "description": "Seat position on vehicle z-axis. Position is relative within available movable range of the seating. 0 = Lowermost position supported.",
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "mm"
+                      },
+                      "IsBelted": {
+                        "datatype": "boolean",
+                        "description": "Is the belt engaged.",
+                        "type": "sensor"
+                      },
+                      "IsOccupied": {
+                        "datatype": "boolean",
+                        "description": "Does the seat have a passenger in it.",
+                        "type": "sensor"
+                      },
+                      "Massage": {
+                        "datatype": "uint8",
+                        "description": "Seat massage level. 0 = off. 100 = max massage.",
+                        "max": 100,
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "percent"
+                      },
+                      "Occupant": {
+                        "children": {
+                          "Identifier": {
+                            "children": {
+                              "Issuer": {
+                                "datatype": "string",
+                                "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                                "description": "Unique Issuer for the authentication of the occupant e.g. https://accounts.funcorp.com.",
+                                "type": "sensor"
+                              },
+                              "Subject": {
+                                "datatype": "string",
+                                "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                                "description": "Subject for the authentication of the occupant e.g. UserID 7331677.",
+                                "type": "sensor"
+                              }
+                            },
+                            "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                            "description": "Identifier attributes based on OAuth 2.0.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Occupant data.",
+                        "type": "branch"
+                      },
+                      "Position": {
+                        "datatype": "uint16",
+                        "description": "Seat position on vehicle x-axis. Position is relative to the frontmost position supported by the seat. 0 = Frontmost position supported.",
+                        "min": 0,
+                        "type": "actuator",
+                        "unit": "mm"
+                      },
+                      "SeatBeltHeight": {
+                        "datatype": "uint16",
+                        "description": "Seat belt position on vehicle z-axis. Position is relative within available movable range of the seat belt. 0 = Lowermost position supported.",
+                        "type": "actuator",
+                        "unit": "mm"
+                      },
+                      "Seating": {
+                        "children": {
+                          "Length": {
+                            "datatype": "uint16",
+                            "description": "Length adjustment of seating. 0 = Adjustable part of seating in rearmost position (Shortest length of seating).",
+                            "min": 0,
+                            "type": "actuator",
+                            "unit": "mm"
+                          }
+                        },
+                        "comment": "Seating is here considered as the part of the seat that supports the thighs. Additional cushions (if any) for support of lower legs is not covered by this branch.",
+                        "description": "Describes signals related to the seat bottom of the seat.",
+                        "type": "branch"
+                      },
+                      "Switch": {
+                        "children": {
+                          "Backrest": {
+                            "children": {
+                              "IsReclineBackwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Backrest recline backward switch engaged (SingleSeat.Backrest.Recline).",
+                                "type": "actuator"
+                              },
+                              "IsReclineForwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Backrest recline forward switch engaged (SingleSeat.Backrest.Recline).",
+                                "type": "actuator"
+                              },
+                              "Lumbar": {
+                                "children": {
+                                  "IsDownEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Lumbar down switch engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsLessSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for less lumbar support engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsMoreSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for more lumbar support engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsUpEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Lumbar up switch engaged (SingleSeat.Backrest.Lumbar.Support).",
+                                    "type": "actuator"
+                                  }
+                                },
+                                "description": "Switches for SingleSeat.Backrest.Lumbar.",
+                                "type": "branch"
+                              },
+                              "SideBolster": {
+                                "children": {
+                                  "IsLessSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for less side bolster support engaged (SingleSeat.Backrest.SideBolster.Support).",
+                                    "type": "actuator"
+                                  },
+                                  "IsMoreSupportEngaged": {
+                                    "datatype": "boolean",
+                                    "description": "Is switch for more side bolster support engaged (SingleSeat.Backrest.SideBolster.Support).",
+                                    "type": "actuator"
+                                  }
+                                },
+                                "description": "Switches for SingleSeat.Backrest.SideBolster.",
+                                "type": "branch"
+                              }
+                            },
+                            "description": "Describes switches related to the backrest of the seat.",
+                            "type": "branch"
+                          },
+                          "Headrest": {
+                            "children": {
+                              "IsBackwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest backward switch engaged (SingleSeat.Headrest.Angle).",
+                                "type": "actuator"
+                              },
+                              "IsDownEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest down switch engaged (SingleSeat.Headrest.Height).",
+                                "type": "actuator"
+                              },
+                              "IsForwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest forward switch engaged (SingleSeat.Headrest.Angle).",
+                                "type": "actuator"
+                              },
+                              "IsUpEngaged": {
+                                "datatype": "boolean",
+                                "description": "Head rest up switch engaged (SingleSeat.Headrest.Height).",
+                                "type": "actuator"
+                              }
+                            },
+                            "description": "Switches for SingleSeat.Headrest.",
+                            "type": "branch"
+                          },
+                          "IsBackwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat backward switch engaged (SingleSeat.Position).",
+                            "type": "actuator"
+                          },
+                          "IsCoolerEngaged": {
+                            "datatype": "boolean",
+                            "description": "Cooler switch for Seat heater (SingleSeat.Heating).",
+                            "type": "actuator"
+                          },
+                          "IsDownEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat down switch engaged (SingleSeat.Height).",
+                            "type": "actuator"
+                          },
+                          "IsForwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat forward switch engaged (SingleSeat.Position).",
+                            "type": "actuator"
+                          },
+                          "IsTiltBackwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Tilt backward switch engaged (SingleSeat.Tilt).",
+                            "type": "actuator"
+                          },
+                          "IsTiltForwardEngaged": {
+                            "datatype": "boolean",
+                            "description": "Tilt forward switch engaged (SingleSeat.Tilt).",
+                            "type": "actuator"
+                          },
+                          "IsUpEngaged": {
+                            "datatype": "boolean",
+                            "description": "Seat up switch engaged (SingleSeat.Height).",
+                            "type": "actuator"
+                          },
+                          "IsWarmerEngaged": {
+                            "datatype": "boolean",
+                            "description": "Warmer switch for Seat heater (SingleSeat.Heating).",
+                            "type": "actuator"
+                          },
+                          "Massage": {
+                            "children": {
+                              "IsDecreaseEngaged": {
+                                "datatype": "boolean",
+                                "description": "Decrease massage level switch engaged (SingleSeat.Massage).",
+                                "type": "actuator"
+                              },
+                              "IsIncreaseEngaged": {
+                                "datatype": "boolean",
+                                "description": "Increase massage level switch engaged (SingleSeat.Massage).",
+                                "type": "actuator"
+                              }
+                            },
+                            "description": "Switches for SingleSeat.Massage.",
+                            "type": "branch"
+                          },
+                          "Seating": {
+                            "children": {
+                              "IsBackwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Is switch to decrease seating length engaged (SingleSeat.Seating.Length).",
+                                "type": "actuator"
+                              },
+                              "IsForwardEngaged": {
+                                "datatype": "boolean",
+                                "description": "Is switch to increase seating length engaged (SingleSeat.Seating.Length).",
+                                "type": "actuator"
+                              }
+                            },
+                            "description": "Describes switches related to the seating of the seat.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Seat switch signals",
+                        "type": "branch"
+                      },
+                      "Tilt": {
+                        "comment": "In VSS it is assumed that tilting a seat affects both seating (seat bottom) and backrest, i.e. the angle between seating and backrest will not be affected when changing Tilt.",
+                        "datatype": "float",
+                        "description": "Tilting of seat (seating and backrest) relative to vehicle x-axis. 0 = seat bottom is flat, seat bottom and vehicle x-axis are parallel. Positive degrees = seat tilted backwards, seat x-axis tilted upward, seat z-axis is tilted backward.",
+                        "type": "actuator",
+                        "unit": "degrees"
+                      }
+                    },
+                    "description": "All seats.",
+                    "type": "branch"
+                  }
+                },
+                "description": "All seats.",
+                "type": "branch"
+              }
+            },
+            "description": "All seats.",
+            "type": "branch"
+          },
+          "SeatPosCount": {
+            "comment": "Default value corresponds to two seats in front row and 3 seats in second row.",
+            "datatype": "uint8[]",
+            "default": [
+              2,
+              3
+            ],
+            "description": "Number of seats across each row from the front to the rear.",
+            "type": "attribute"
+          },
+          "SeatRowCount": {
+            "comment": "Default value corresponds to two rows of seats.",
+            "datatype": "uint8",
+            "default": 2,
+            "description": "Number of seat rows in vehicle.",
+            "type": "attribute"
+          },
+          "Sunroof": {
+            "children": {
+              "Position": {
+                "datatype": "int8",
+                "description": "Sunroof position. 0 = Fully closed 100 = Fully opened. -100 = Fully tilted.",
+                "max": 100,
+                "min": -100,
+                "type": "sensor",
+                "unit": "percent"
+              },
+              "Shade": {
+                "children": {
+                  "IsOpen": {
+                    "datatype": "boolean",
+                    "description": "Is item open or closed? True = Fully or partially open. False = Fully closed.",
+                    "type": "actuator"
+                  },
+                  "Position": {
+                    "comment": "Relationship between Open/Close and Start/End position is item dependent.",
+                    "datatype": "uint8",
+                    "description": "Item position. 0 = Start position 100 = End position.",
+                    "max": 100,
+                    "min": 0,
+                    "type": "actuator",
+                    "unit": "percent"
+                  },
+                  "Switch": {
+                    "allowed": [
+                      "INACTIVE",
+                      "CLOSE",
+                      "OPEN",
+                      "ONE_SHOT_CLOSE",
+                      "ONE_SHOT_OPEN"
+                    ],
+                    "datatype": "string",
+                    "description": "Switch controlling sliding action such as window, sunroof, or blind.",
+                    "type": "actuator"
+                  }
+                },
+                "description": "Sun roof shade status. Open = Retracted, Closed = Deployed. Start position for Sunroof.Shade is Open/Retracted.",
+                "type": "branch"
+              },
+              "Switch": {
+                "allowed": [
+                  "INACTIVE",
+                  "CLOSE",
+                  "OPEN",
+                  "ONE_SHOT_CLOSE",
+                  "ONE_SHOT_OPEN",
+                  "TILT_UP",
+                  "TILT_DOWN"
+                ],
+                "datatype": "string",
+                "description": "Switch controlling sliding action such as window, sunroof, or shade.",
+                "type": "actuator"
+              }
+            },
+            "description": "Sun roof status.",
+            "type": "branch"
+          }
+        },
+        "description": "All in-cabin components, including doors.",
+        "type": "branch"
+      },
+      "CargoVolume": {
+        "datatype": "float",
+        "description": "The available volume for cargo or luggage. For automobiles, this is usually the trunk volume.",
+        "min": 0,
+        "type": "attribute",
+        "unit": "l"
+      },
+      "Chassis": {
+        "children": {
+          "Accelerator": {
+            "children": {
+              "PedalPosition": {
+                "datatype": "uint8",
+                "description": "Accelerator pedal position as percent. 0 = Not depressed. 100 = Fully depressed.",
+                "max": 100,
+                "min": 0,
+                "type": "sensor",
+                "unit": "percent"
+              }
+            },
+            "description": "Accelerator signals",
+            "type": "branch"
+          },
+          "Axle": {
+            "children": {
+              "Row1": {
+                "children": {
+                  "AxleWidth": {
+                    "comment": "Corresponds to SAE J1100-2009 W113.",
+                    "datatype": "uint16",
+                    "description": "The lateral distance between the wheel mounting faces, measured along the spindle axis.",
+                    "type": "attribute",
+                    "unit": "mm"
+                  },
+                  "SteeringAngle": {
+                    "comment": "Single track two-axle model steering angle refers to the angle that a centrally mounted wheel would have.",
+                    "datatype": "float",
+                    "description": "Single track two-axle model steering angle. Angle according to ISO 8855. Positive = degrees to the left. Negative = degrees to the right.",
+                    "type": "sensor",
+                    "unit": "degrees"
+                  },
+                  "TireAspectRatio": {
+                    "datatype": "uint8",
+                    "description": "Aspect ratio between tire section height and tire section width, as per ETRTO / TRA standard.",
+                    "type": "attribute",
+                    "unit": "percent"
+                  },
+                  "TireDiameter": {
+                    "datatype": "float",
+                    "description": "Outer diameter of tires, in inches, as per ETRTO / TRA standard.",
+                    "type": "attribute",
+                    "unit": "inch"
+                  },
+                  "TireWidth": {
+                    "datatype": "uint16",
+                    "description": "Nominal section width of tires, in mm, as per ETRTO / TRA standard.",
+                    "type": "attribute",
+                    "unit": "mm"
+                  },
+                  "TrackWidth": {
+                    "comment": "Corresponds to SAE J1100-2009 W102.",
+                    "datatype": "uint16",
+                    "description": "The lateral distance between the centers of the wheels, measured along the spindle, or axle axis. If there are dual rear wheels, measure from the midway points between the inner and outer tires.",
+                    "type": "attribute",
+                    "unit": "mm"
+                  },
+                  "TreadWidth": {
+                    "comment": "Corresponds to SAE J1100-2009 W101.",
+                    "datatype": "uint16",
+                    "description": "The lateral distance between the centerlines of the base tires at ground, including camber angle. If there are dual rear wheels, measure from the midway points between the inner and outer tires.",
+                    "type": "attribute",
+                    "unit": "mm"
+                  },
+                  "Wheel": {
+                    "children": {
+                      "Left": {
+                        "children": {
+                          "AngularSpeed": {
+                            "comment": "Positive if wheel is trying to drive vehicle forward. Negative if wheel is trying to drive vehicle backward.",
+                            "datatype": "float",
+                            "description": "Angular (Rotational) speed of a vehicle's wheel.",
+                            "type": "sensor",
+                            "unit": "degrees/s"
+                          },
+                          "Brake": {
+                            "children": {
+                              "FluidLevel": {
+                                "datatype": "uint8",
+                                "description": "Brake fluid level as percent. 0 = Empty. 100 = Full.",
+                                "max": 100,
+                                "type": "sensor",
+                                "unit": "percent"
+                              },
+                              "IsBrakesWorn": {
+                                "datatype": "boolean",
+                                "description": "Brake pad wear status. True = Worn. False = Not Worn.",
+                                "type": "sensor"
+                              },
+                              "IsFluidLevelLow": {
+                                "datatype": "boolean",
+                                "dbc2vss": {
+                                  "interval_ms": 1000,
+                                  "signal": "VCFRONT_brakeFluidLevel",
+                                  "transform": {
+                                    "mapping": [
+                                      {
+                                        "from": "LOW",
+                                        "to": true
+                                      },
+                                      {
+                                        "from": "NORMAL",
+                                        "to": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                "description": "Brake fluid level status. True = Brake fluid level low. False = Brake fluid level OK.",
+                                "type": "sensor"
+                              },
+                              "PadWear": {
+                                "datatype": "uint8",
+                                "description": "Brake pad wear as percent. 0 = No Wear. 100 = Worn.",
+                                "max": 100,
+                                "type": "sensor",
+                                "unit": "percent"
+                              }
+                            },
+                            "description": "Brake signals for wheel",
+                            "type": "branch"
+                          },
+                          "Speed": {
+                            "datatype": "float",
+                            "description": "Linear speed of a vehicle's wheel.",
+                            "type": "sensor",
+                            "unit": "km/h"
+                          },
+                          "Tire": {
+                            "children": {
+                              "IsPressureLow": {
+                                "datatype": "boolean",
+                                "description": "Tire Pressure Status. True = Low tire pressure. False = Good tire pressure.",
+                                "type": "sensor"
+                              },
+                              "Pressure": {
+                                "datatype": "uint16",
+                                "description": "Tire pressure in kilo-Pascal.",
+                                "type": "sensor",
+                                "unit": "kPa"
+                              },
+                              "Temperature": {
+                                "datatype": "float",
+                                "description": "Tire temperature in Celsius.",
+                                "type": "sensor",
+                                "unit": "celsius"
+                              }
+                            },
+                            "description": "Tire signals for wheel.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Wheel signals for axle",
+                        "type": "branch"
+                      },
+                      "Right": {
+                        "children": {
+                          "AngularSpeed": {
+                            "comment": "Positive if wheel is trying to drive vehicle forward. Negative if wheel is trying to drive vehicle backward.",
+                            "datatype": "float",
+                            "description": "Angular (Rotational) speed of a vehicle's wheel.",
+                            "type": "sensor",
+                            "unit": "degrees/s"
+                          },
+                          "Brake": {
+                            "children": {
+                              "FluidLevel": {
+                                "datatype": "uint8",
+                                "description": "Brake fluid level as percent. 0 = Empty. 100 = Full.",
+                                "max": 100,
+                                "type": "sensor",
+                                "unit": "percent"
+                              },
+                              "IsBrakesWorn": {
+                                "datatype": "boolean",
+                                "description": "Brake pad wear status. True = Worn. False = Not Worn.",
+                                "type": "sensor"
+                              },
+                              "IsFluidLevelLow": {
+                                "datatype": "boolean",
+                                "dbc2vss": {
+                                  "interval_ms": 1000,
+                                  "signal": "VCFRONT_brakeFluidLevel",
+                                  "transform": {
+                                    "mapping": [
+                                      {
+                                        "from": "LOW",
+                                        "to": true
+                                      },
+                                      {
+                                        "from": "NORMAL",
+                                        "to": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                "description": "Brake fluid level status. True = Brake fluid level low. False = Brake fluid level OK.",
+                                "type": "sensor"
+                              },
+                              "PadWear": {
+                                "datatype": "uint8",
+                                "description": "Brake pad wear as percent. 0 = No Wear. 100 = Worn.",
+                                "max": 100,
+                                "type": "sensor",
+                                "unit": "percent"
+                              }
+                            },
+                            "description": "Brake signals for wheel",
+                            "type": "branch"
+                          },
+                          "Speed": {
+                            "datatype": "float",
+                            "description": "Linear speed of a vehicle's wheel.",
+                            "type": "sensor",
+                            "unit": "km/h"
+                          },
+                          "Tire": {
+                            "children": {
+                              "IsPressureLow": {
+                                "datatype": "boolean",
+                                "description": "Tire Pressure Status. True = Low tire pressure. False = Good tire pressure.",
+                                "type": "sensor"
+                              },
+                              "Pressure": {
+                                "datatype": "uint16",
+                                "description": "Tire pressure in kilo-Pascal.",
+                                "type": "sensor",
+                                "unit": "kPa"
+                              },
+                              "Temperature": {
+                                "datatype": "float",
+                                "description": "Tire temperature in Celsius.",
+                                "type": "sensor",
+                                "unit": "celsius"
+                              }
+                            },
+                            "description": "Tire signals for wheel.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Wheel signals for axle",
+                        "type": "branch"
+                      }
+                    },
+                    "description": "Wheel signals for axle",
+                    "type": "branch"
+                  },
+                  "WheelCount": {
+                    "datatype": "uint8",
+                    "description": "Number of wheels on the axle",
+                    "type": "attribute"
+                  },
+                  "WheelDiameter": {
+                    "datatype": "float",
+                    "description": "Diameter of wheels (rims without tires), in inches, as per ETRTO / TRA standard.",
+                    "type": "attribute",
+                    "unit": "inch"
+                  },
+                  "WheelWidth": {
+                    "datatype": "float",
+                    "description": "Width of wheels (rims without tires), in inches, as per ETRTO / TRA standard.",
+                    "type": "attribute",
+                    "unit": "inch"
+                  }
+                },
+                "description": "Axle signals",
+                "type": "branch"
+              },
+              "Row2": {
+                "children": {
+                  "AxleWidth": {
+                    "comment": "Corresponds to SAE J1100-2009 W113.",
+                    "datatype": "uint16",
+                    "description": "The lateral distance between the wheel mounting faces, measured along the spindle axis.",
+                    "type": "attribute",
+                    "unit": "mm"
+                  },
+                  "SteeringAngle": {
+                    "comment": "Single track two-axle model steering angle refers to the angle that a centrally mounted wheel would have.",
+                    "datatype": "float",
+                    "description": "Single track two-axle model steering angle. Angle according to ISO 8855. Positive = degrees to the left. Negative = degrees to the right.",
+                    "type": "sensor",
+                    "unit": "degrees"
+                  },
+                  "TireAspectRatio": {
+                    "datatype": "uint8",
+                    "description": "Aspect ratio between tire section height and tire section width, as per ETRTO / TRA standard.",
+                    "type": "attribute",
+                    "unit": "percent"
+                  },
+                  "TireDiameter": {
+                    "datatype": "float",
+                    "description": "Outer diameter of tires, in inches, as per ETRTO / TRA standard.",
+                    "type": "attribute",
+                    "unit": "inch"
+                  },
+                  "TireWidth": {
+                    "datatype": "uint16",
+                    "description": "Nominal section width of tires, in mm, as per ETRTO / TRA standard.",
+                    "type": "attribute",
+                    "unit": "mm"
+                  },
+                  "TrackWidth": {
+                    "comment": "Corresponds to SAE J1100-2009 W102.",
+                    "datatype": "uint16",
+                    "description": "The lateral distance between the centers of the wheels, measured along the spindle, or axle axis. If there are dual rear wheels, measure from the midway points between the inner and outer tires.",
+                    "type": "attribute",
+                    "unit": "mm"
+                  },
+                  "TreadWidth": {
+                    "comment": "Corresponds to SAE J1100-2009 W101.",
+                    "datatype": "uint16",
+                    "description": "The lateral distance between the centerlines of the base tires at ground, including camber angle. If there are dual rear wheels, measure from the midway points between the inner and outer tires.",
+                    "type": "attribute",
+                    "unit": "mm"
+                  },
+                  "Wheel": {
+                    "children": {
+                      "Left": {
+                        "children": {
+                          "AngularSpeed": {
+                            "comment": "Positive if wheel is trying to drive vehicle forward. Negative if wheel is trying to drive vehicle backward.",
+                            "datatype": "float",
+                            "description": "Angular (Rotational) speed of a vehicle's wheel.",
+                            "type": "sensor",
+                            "unit": "degrees/s"
+                          },
+                          "Brake": {
+                            "children": {
+                              "FluidLevel": {
+                                "datatype": "uint8",
+                                "description": "Brake fluid level as percent. 0 = Empty. 100 = Full.",
+                                "max": 100,
+                                "type": "sensor",
+                                "unit": "percent"
+                              },
+                              "IsBrakesWorn": {
+                                "datatype": "boolean",
+                                "description": "Brake pad wear status. True = Worn. False = Not Worn.",
+                                "type": "sensor"
+                              },
+                              "IsFluidLevelLow": {
+                                "datatype": "boolean",
+                                "dbc2vss": {
+                                  "interval_ms": 1000,
+                                  "signal": "VCFRONT_brakeFluidLevel",
+                                  "transform": {
+                                    "mapping": [
+                                      {
+                                        "from": "LOW",
+                                        "to": true
+                                      },
+                                      {
+                                        "from": "NORMAL",
+                                        "to": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                "description": "Brake fluid level status. True = Brake fluid level low. False = Brake fluid level OK.",
+                                "type": "sensor"
+                              },
+                              "PadWear": {
+                                "datatype": "uint8",
+                                "description": "Brake pad wear as percent. 0 = No Wear. 100 = Worn.",
+                                "max": 100,
+                                "type": "sensor",
+                                "unit": "percent"
+                              }
+                            },
+                            "description": "Brake signals for wheel",
+                            "type": "branch"
+                          },
+                          "Speed": {
+                            "datatype": "float",
+                            "description": "Linear speed of a vehicle's wheel.",
+                            "type": "sensor",
+                            "unit": "km/h"
+                          },
+                          "Tire": {
+                            "children": {
+                              "IsPressureLow": {
+                                "datatype": "boolean",
+                                "description": "Tire Pressure Status. True = Low tire pressure. False = Good tire pressure.",
+                                "type": "sensor"
+                              },
+                              "Pressure": {
+                                "datatype": "uint16",
+                                "description": "Tire pressure in kilo-Pascal.",
+                                "type": "sensor",
+                                "unit": "kPa"
+                              },
+                              "Temperature": {
+                                "datatype": "float",
+                                "description": "Tire temperature in Celsius.",
+                                "type": "sensor",
+                                "unit": "celsius"
+                              }
+                            },
+                            "description": "Tire signals for wheel.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Wheel signals for axle",
+                        "type": "branch"
+                      },
+                      "Right": {
+                        "children": {
+                          "AngularSpeed": {
+                            "comment": "Positive if wheel is trying to drive vehicle forward. Negative if wheel is trying to drive vehicle backward.",
+                            "datatype": "float",
+                            "description": "Angular (Rotational) speed of a vehicle's wheel.",
+                            "type": "sensor",
+                            "unit": "degrees/s"
+                          },
+                          "Brake": {
+                            "children": {
+                              "FluidLevel": {
+                                "datatype": "uint8",
+                                "description": "Brake fluid level as percent. 0 = Empty. 100 = Full.",
+                                "max": 100,
+                                "type": "sensor",
+                                "unit": "percent"
+                              },
+                              "IsBrakesWorn": {
+                                "datatype": "boolean",
+                                "description": "Brake pad wear status. True = Worn. False = Not Worn.",
+                                "type": "sensor"
+                              },
+                              "IsFluidLevelLow": {
+                                "datatype": "boolean",
+                                "dbc2vss": {
+                                  "interval_ms": 1000,
+                                  "signal": "VCFRONT_brakeFluidLevel",
+                                  "transform": {
+                                    "mapping": [
+                                      {
+                                        "from": "LOW",
+                                        "to": true
+                                      },
+                                      {
+                                        "from": "NORMAL",
+                                        "to": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                "description": "Brake fluid level status. True = Brake fluid level low. False = Brake fluid level OK.",
+                                "type": "sensor"
+                              },
+                              "PadWear": {
+                                "datatype": "uint8",
+                                "description": "Brake pad wear as percent. 0 = No Wear. 100 = Worn.",
+                                "max": 100,
+                                "type": "sensor",
+                                "unit": "percent"
+                              }
+                            },
+                            "description": "Brake signals for wheel",
+                            "type": "branch"
+                          },
+                          "Speed": {
+                            "datatype": "float",
+                            "description": "Linear speed of a vehicle's wheel.",
+                            "type": "sensor",
+                            "unit": "km/h"
+                          },
+                          "Tire": {
+                            "children": {
+                              "IsPressureLow": {
+                                "datatype": "boolean",
+                                "description": "Tire Pressure Status. True = Low tire pressure. False = Good tire pressure.",
+                                "type": "sensor"
+                              },
+                              "Pressure": {
+                                "datatype": "uint16",
+                                "description": "Tire pressure in kilo-Pascal.",
+                                "type": "sensor",
+                                "unit": "kPa"
+                              },
+                              "Temperature": {
+                                "datatype": "float",
+                                "description": "Tire temperature in Celsius.",
+                                "type": "sensor",
+                                "unit": "celsius"
+                              }
+                            },
+                            "description": "Tire signals for wheel.",
+                            "type": "branch"
+                          }
+                        },
+                        "description": "Wheel signals for axle",
+                        "type": "branch"
+                      }
+                    },
+                    "description": "Wheel signals for axle",
+                    "type": "branch"
+                  },
+                  "WheelCount": {
+                    "datatype": "uint8",
+                    "description": "Number of wheels on the axle",
+                    "type": "attribute"
+                  },
+                  "WheelDiameter": {
+                    "datatype": "float",
+                    "description": "Diameter of wheels (rims without tires), in inches, as per ETRTO / TRA standard.",
+                    "type": "attribute",
+                    "unit": "inch"
+                  },
+                  "WheelWidth": {
+                    "datatype": "float",
+                    "description": "Width of wheels (rims without tires), in inches, as per ETRTO / TRA standard.",
+                    "type": "attribute",
+                    "unit": "inch"
+                  }
+                },
+                "description": "Axle signals",
+                "type": "branch"
+              }
+            },
+            "description": "Axle signals",
+            "type": "branch"
+          },
+          "AxleCount": {
+            "datatype": "uint8",
+            "default": 2,
+            "description": "Number of axles on the vehicle",
+            "type": "attribute"
+          },
+          "Brake": {
+            "children": {
+              "IsDriverEmergencyBrakingDetected": {
+                "comment": "Detection of emergency braking can trigger Emergency Brake Assist (EBA) to engage.",
+                "datatype": "boolean",
+                "description": "Indicates if emergency braking initiated by driver is detected. True = Emergency braking detected. False = Emergency braking not detected.",
+                "type": "sensor"
+              },
+              "PedalPosition": {
+                "datatype": "uint8",
+                "description": "Brake pedal position as percent. 0 = Not depressed. 100 = Fully depressed.",
+                "max": 100,
+                "min": 0,
+                "type": "sensor",
+                "unit": "percent"
+              }
+            },
+            "description": "Brake system signals",
+            "type": "branch"
+          },
+          "ParkingBrake": {
+            "children": {
+              "IsAutoApplyEnabled": {
+                "datatype": "boolean",
+                "description": "Indicates if parking brake will be automatically engaged when the vehicle engine is turned off.",
+                "type": "actuator"
+              },
+              "IsEngaged": {
+                "datatype": "boolean",
+                "description": "Parking brake status. True = Parking Brake is Engaged. False = Parking Brake is not Engaged.",
+                "type": "actuator"
+              }
+            },
+            "description": "Parking brake signals",
+            "type": "branch"
+          },
+          "SteeringWheel": {
+            "children": {
+              "Angle": {
+                "datatype": "int16",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "SteeringAngle129",
+                  "transform": {
+                    "math": "floor(x+0.5)"
+                  }
+                },
+                "description": "Steering wheel angle. Positive = degrees to the left. Negative = degrees to the right.",
+                "type": "sensor",
+                "unit": "degrees"
+              },
+              "Extension": {
+                "datatype": "uint8",
+                "description": "Steering wheel column extension from dashboard. 0 = Closest to dashboard. 100 = Furthest from dashboard.",
+                "max": 100,
+                "min": 0,
+                "type": "actuator",
+                "unit": "percent"
+              },
+              "HeatingCooling": {
+                "datatype": "int8",
+                "description": "Heating or Cooling requsted for the Item. -100 = Maximum cooling, 0 = Heating/cooling deactivated, 100 = Maximum heating.",
+                "max": 100,
+                "min": -100,
+                "type": "actuator",
+                "unit": "percent"
+              },
+              "Tilt": {
+                "datatype": "uint8",
+                "description": "Steering wheel column tilt. 0 = Lowest position. 100 = Highest position.",
+                "max": 100,
+                "min": 0,
+                "type": "actuator",
+                "unit": "percent"
+              }
+            },
+            "description": "Steering wheel signals",
+            "type": "branch"
+          },
+          "Wheelbase": {
+            "datatype": "uint16",
+            "default": 0,
+            "description": "Overall wheelbase, in mm.",
+            "type": "attribute",
+            "unit": "mm"
+          }
+        },
+        "description": "All data concerning steering, suspension, wheels, and brakes.",
+        "type": "branch"
+      },
+      "Connectivity": {
+        "children": {
+          "IsConnectivityAvailable": {
+            "comment": "This signal can be used by onboard vehicle services to decide what features that shall be offered to the driver, for example disable the 'check for update' button if vehicle does not have connectivity.",
+            "datatype": "boolean",
+            "description": "Indicates if connectivity between vehicle and cloud is available. True = Connectivity is available. False = Connectivity is not available.",
+            "type": "sensor"
+          }
+        },
+        "description": "Connectivity data.",
+        "type": "branch"
+      },
+      "CurbWeight": {
+        "datatype": "uint16",
+        "default": 0,
+        "description": "Vehicle curb weight, including all liquids and full tank of fuel, but no cargo or passengers.",
+        "type": "attribute",
+        "unit": "kg"
+      },
+      "CurrentLocation": {
+        "children": {
+          "Altitude": {
+            "datatype": "double",
+            "description": "Current altitude relative to WGS 84 reference ellipsoid, as measured at the position of GNSS receiver antenna.",
+            "type": "sensor",
+            "unit": "m"
+          },
+          "GNSSReceiver": {
+            "children": {
+              "FixType": {
+                "allowed": [
+                  "NONE",
+                  "TWO_D",
+                  "TWO_D_SATELLITE_BASED_AUGMENTATION",
+                  "TWO_D_GROUND_BASED_AUGMENTATION",
+                  "TWO_D_SATELLITE_AND_GROUND_BASED_AUGMENTATION",
+                  "THREE_D",
+                  "THREE_D_SATELLITE_BASED_AUGMENTATION",
+                  "THREE_D_GROUND_BASED_AUGMENTATION",
+                  "THREE_D_SATELLITE_AND_GROUND_BASED_AUGMENTATION"
+                ],
+                "datatype": "string",
+                "description": "Fix status of GNSS receiver.",
+                "type": "sensor"
+              },
+              "MountingPosition": {
+                "children": {
+                  "X": {
+                    "datatype": "int16",
+                    "description": "Mounting position of GNSS receiver antenna relative to vehicle coordinate system. Axis definitions according to ISO 8855. Origin at center of (first) rear axle. Positive values = forward of rear axle. Negative values = backward of rear axle.",
+                    "type": "attribute",
+                    "unit": "mm"
+                  },
+                  "Y": {
+                    "datatype": "int16",
+                    "description": "Mounting position of GNSS receiver antenna relative to vehicle coordinate system. Axis definitions according to ISO 8855. Origin at center of (first) rear axle. Positive values = left of origin. Negative values = right of origin. Left/Right is as seen from driver perspective, i.e. by a person looking forward.",
+                    "type": "attribute",
+                    "unit": "mm"
+                  },
+                  "Z": {
+                    "datatype": "int16",
+                    "description": "Mounting position of GNSS receiver on Z-axis. Axis definitions according to ISO 8855. Origin at center of (first) rear axle. Positive values = above center of rear axle. Negative values = below center of rear axle.",
+                    "type": "attribute",
+                    "unit": "mm"
+                  }
+                },
+                "description": "Mounting position of GNSS receiver antenna relative to vehicle coordinate system. Axis definitions according to ISO 8855. Origin at center of (first) rear axle.",
+                "type": "branch"
+              }
+            },
+            "description": "Information on the GNSS receiver used for determining current location.",
+            "type": "branch"
+          },
+          "Heading": {
+            "datatype": "double",
+            "description": "Current heading relative to geographic north. 0 = North, 90 = East, 180 = South, 270 = West.",
+            "max": 360,
+            "min": 0,
+            "type": "sensor",
+            "unit": "degrees"
+          },
+          "HorizontalAccuracy": {
+            "datatype": "double",
+            "description": "Accuracy of the latitude and longitude coordinates.",
+            "type": "sensor",
+            "unit": "m"
+          },
+          "Latitude": {
+            "datatype": "double",
+            "description": "Current latitude of vehicle in WGS 84 geodetic coordinates, as measured at the position of GNSS receiver antenna.",
+            "max": 90,
+            "min": -90,
+            "type": "sensor",
+            "unit": "degrees"
+          },
+          "Longitude": {
+            "datatype": "double",
+            "description": "Current longitude of vehicle in WGS 84 geodetic coordinates, as measured at the position of GNSS receiver antenna.",
+            "max": 180,
+            "min": -180,
+            "type": "sensor",
+            "unit": "degrees"
+          },
+          "Timestamp": {
+            "datatype": "string",
+            "description": "Timestamp from GNSS system for current location, formatted according to ISO 8601 with UTC time zone.",
+            "type": "sensor",
+            "unit": "iso8601"
+          },
+          "VerticalAccuracy": {
+            "datatype": "double",
+            "description": "Accuracy of altitude.",
+            "type": "sensor",
+            "unit": "m"
+          }
+        },
+        "description": "The current latitude and longitude of the vehicle.",
+        "type": "branch"
+      },
+      "CurrentOverallWeight": {
+        "datatype": "uint16",
+        "description": "Current overall Vehicle weight. Including passengers, cargo and other load inside the car.",
+        "type": "sensor",
+        "unit": "kg"
+      },
+      "Diagnostics": {
+        "children": {
+          "DTCCount": {
+            "datatype": "uint8",
+            "description": "Number of Diagnostic Trouble Codes (DTC)",
+            "type": "sensor"
+          },
+          "DTCList": {
+            "datatype": "string[]",
+            "description": "List of currently active DTCs formatted according OBD II (SAE-J2012DA_201812) standard ([P|C|B|U]XXXXX )",
+            "type": "sensor"
+          }
+        },
+        "description": "Diagnostics data.",
+        "type": "branch"
+      },
+      "Driver": {
+        "children": {
+          "AttentiveProbability": {
+            "datatype": "float",
+            "description": "Probability of attentiveness of the driver.",
+            "max": 100,
+            "min": 0,
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "DistractionLevel": {
+            "datatype": "float",
+            "description": "Distraction level of the driver, which can be evaluated by multiple factors e.g. driving situation, acoustical or optical signals inside the cockpit, ongoing phone calls.",
+            "max": 100,
+            "min": 0,
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "FatigueLevel": {
+            "datatype": "float",
+            "description": "Fatigue level of the driver, which can be evaluated by multiple factors e.g. trip time, behaviour of steering, eye status.",
+            "max": 100,
+            "min": 0,
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "HeartRate": {
+            "datatype": "uint16",
+            "description": "Heart rate of the driver.",
+            "type": "sensor",
+            "unit": "bpm"
+          },
+          "Identifier": {
+            "children": {
+              "Issuer": {
+                "datatype": "string",
+                "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                "description": "Unique Issuer for the authentication of the occupant e.g. https://accounts.funcorp.com.",
+                "type": "sensor"
+              },
+              "Subject": {
+                "datatype": "string",
+                "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+                "description": "Subject for the authentication of the occupant e.g. UserID 7331677.",
+                "type": "sensor"
+              }
+            },
+            "deprecation": "v5.0 - use data from Vehicle.Occupant.*.*.Identifier.",
+            "description": "Identifier attributes based on OAuth 2.0.",
+            "type": "branch"
+          },
+          "IsEyesOnRoad": {
+            "datatype": "boolean",
+            "description": "Has driver the eyes on road or not?",
+            "type": "sensor"
+          },
+          "IsHandsOnWheel": {
+            "datatype": "boolean",
+            "description": "Are the driver's hands on the steering wheel or not?",
+            "type": "sensor"
+          }
+        },
+        "description": "Driver data.",
+        "type": "branch"
+      },
+      "EmissionsCO2": {
+        "datatype": "int16",
+        "description": "The CO2 emissions.",
+        "type": "attribute",
+        "unit": "g/km"
+      },
+      "Exterior": {
+        "children": {
+          "AirTemperature": {
+            "datatype": "float",
+            "description": "Air temperature outside the vehicle.",
+            "type": "sensor",
+            "unit": "celsius"
+          },
+          "Humidity": {
+            "datatype": "float",
+            "description": "Relative humidity outside the vehicle. 0 = Dry, 100 = Air fully saturated.",
+            "max": 100,
+            "min": 0,
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "LightIntensity": {
+            "comment": "Mapping to physical units and calculation method is sensor specific.",
+            "datatype": "float",
+            "description": "Light intensity outside the vehicle. 0 = No light detected, 100 = Fully lit.",
+            "max": 100,
+            "min": 0,
+            "type": "sensor",
+            "unit": "percent"
+          }
+        },
+        "description": "Information about exterior measured by vehicle.",
+        "type": "branch"
+      },
+      "GrossWeight": {
+        "datatype": "uint16",
+        "default": 0,
+        "description": "Curb weight of vehicle, including all liquids and full tank of fuel and full load of cargo and passengers.",
+        "type": "attribute",
+        "unit": "kg"
+      },
+      "Height": {
+        "datatype": "uint16",
+        "default": 0,
+        "description": "Overall vehicle height.",
+        "type": "attribute",
+        "unit": "mm"
+      },
+      "IsAutoPowerOptimize": {
+        "datatype": "boolean",
+        "description": "Auto Power Optimization Flag When set to 'true', the system enables automatic power optimization, dynamically adjusting the power optimization level based on runtime conditions or features managed by the OEM. When set to 'false', manual control of the power optimization level is allowed.",
+        "type": "actuator"
+      },
+      "IsBrokenDown": {
+        "comment": "Actual criteria and method used to decide if a vehicle is broken down is implementation specific.",
+        "datatype": "boolean",
+        "description": "Vehicle breakdown or any similar event causing vehicle to stop on the road, that might pose a risk to other road users. True = Vehicle broken down on the road, due to e.g. engine problems, flat tire, out of gas, brake problems. False = Vehicle not broken down.",
+        "type": "sensor"
+      },
+      "IsMoving": {
+        "datatype": "boolean",
+        "description": "Indicates whether the vehicle is stationary or moving.",
+        "type": "sensor"
+      },
+      "Length": {
+        "datatype": "uint16",
+        "default": 0,
+        "description": "Overall vehicle length.",
+        "type": "attribute",
+        "unit": "mm"
+      },
+      "LowVoltageBattery": {
+        "children": {
+          "CurrentCurrent": {
+            "datatype": "float",
+            "description": "Current current flowing in/out of the low voltage battery. Positive = Current flowing in to battery, e.g. during charging or driving. Negative = Current flowing out of battery, e.g. when using the battery to start a combustion engine.",
+            "type": "sensor",
+            "unit": "A"
+          },
+          "CurrentVoltage": {
+            "datatype": "float",
+            "description": "Current Voltage of the low voltage battery.",
+            "type": "sensor",
+            "unit": "V"
+          },
+          "NominalCapacity": {
+            "datatype": "uint16",
+            "description": "Nominal capacity of the low voltage battery.",
+            "type": "attribute",
+            "unit": "Ah"
+          },
+          "NominalVoltage": {
+            "comment": "Nominal voltage typically refers to voltage of fully charged battery when delivering rated capacity.",
+            "datatype": "uint16",
+            "description": "Nominal Voltage of the battery.",
+            "type": "attribute",
+            "unit": "V"
+          }
+        },
+        "description": "Signals related to low voltage battery.",
+        "type": "branch"
+      },
+      "LowVoltageSystemState": {
+        "allowed": [
+          "UNDEFINED",
+          "LOCK",
+          "OFF",
+          "ACC",
+          "ON",
+          "START"
+        ],
+        "datatype": "string",
+        "description": "State of the supply voltage of the control units (usually 12V).",
+        "type": "sensor"
+      },
+      "MaxTowBallWeight": {
+        "datatype": "uint16",
+        "default": 0,
+        "description": "Maximum vertical weight on the tow ball of a trailer.",
+        "type": "attribute",
+        "unit": "kg"
+      },
+      "MaxTowWeight": {
+        "datatype": "uint16",
+        "default": 0,
+        "description": "Maximum weight of trailer.",
+        "type": "attribute",
+        "unit": "kg"
+      },
+      "OBD": {
+        "children": {
+          "AbsoluteLoad": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 43 - Absolute load value",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "AcceleratorPositionD": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 49 - Accelerator pedal position D",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "AcceleratorPositionE": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 4A - Accelerator pedal position E",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "AcceleratorPositionF": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 4B - Accelerator pedal position F",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "AirStatus": {
+            "datatype": "string",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 12 - Secondary air status",
+            "type": "sensor"
+          },
+          "AmbientAirTemperature": {
+            "datatype": "float",
+            "dbc2vss": {
+              "interval_ms": 1000,
+              "signal": "VCFRONT_tempAmbientFiltered"
+            },
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 46 - Ambient air temperature",
+            "type": "sensor",
+            "unit": "celsius"
+          },
+          "BarometricPressure": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 33 - Barometric pressure",
+            "type": "sensor",
+            "unit": "kPa"
+          },
+          "Catalyst": {
+            "children": {
+              "Bank1": {
+                "children": {
+                  "Temperature1": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 3C - Catalyst temperature from bank 1, sensor 1",
+                    "type": "sensor",
+                    "unit": "celsius"
+                  },
+                  "Temperature2": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 3E - Catalyst temperature from bank 1, sensor 2",
+                    "type": "sensor",
+                    "unit": "celsius"
+                  }
+                },
+                "deprecation": "v5.0 OBD-branch is deprecated.",
+                "description": "Catalyst bank 1 signals",
+                "type": "branch"
+              },
+              "Bank2": {
+                "children": {
+                  "Temperature1": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 3D - Catalyst temperature from bank 2, sensor 1",
+                    "type": "sensor",
+                    "unit": "celsius"
+                  },
+                  "Temperature2": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 3F - Catalyst temperature from bank 2, sensor 2",
+                    "type": "sensor",
+                    "unit": "celsius"
+                  }
+                },
+                "deprecation": "v5.0 OBD-branch is deprecated.",
+                "description": "Catalyst bank 2 signals",
+                "type": "branch"
+              }
+            },
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "Catalyst signals",
+            "type": "branch"
+          },
+          "CommandedEGR": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 2C - Commanded exhaust gas recirculation (EGR)",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "CommandedEVAP": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 2E - Commanded evaporative purge (EVAP) valve",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "CommandedEquivalenceRatio": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 44 - Commanded equivalence ratio",
+            "type": "sensor",
+            "unit": "ratio"
+          },
+          "ControlModuleVoltage": {
+            "datatype": "float",
+            "dbc2vss": {
+              "interval_ms": 1000,
+              "signal": "PCS_dcdcLvBusVolt"
+            },
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 42 - Control module voltage",
+            "type": "sensor",
+            "unit": "V"
+          },
+          "CoolantTemperature": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 05 - Coolant temperature",
+            "type": "sensor",
+            "unit": "celsius"
+          },
+          "DTCList": {
+            "datatype": "string[]",
+            "deprecation": "v5.0 replaced with Vehicle.Diagnostics.DTCList",
+            "description": "List of currently active DTCs formatted according OBD II (SAE-J2012DA_201812) standard ([P|C|B|U]XXXXX )",
+            "type": "sensor"
+          },
+          "DistanceSinceDTCClear": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 31 - Distance traveled since codes cleared",
+            "type": "sensor",
+            "unit": "km"
+          },
+          "DistanceWithMIL": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 21 - Distance traveled with MIL on",
+            "type": "sensor",
+            "unit": "km"
+          },
+          "DriveCycleStatus": {
+            "children": {
+              "DTCCount": {
+                "datatype": "uint8",
+                "deprecation": "v5.0 OBD-branch is deprecated.",
+                "description": "Number of sensor Trouble Codes (DTC)",
+                "type": "sensor"
+              },
+              "IgnitionType": {
+                "allowed": [
+                  "SPARK",
+                  "COMPRESSION"
+                ],
+                "datatype": "string",
+                "deprecation": "v5.0 OBD-branch is deprecated.",
+                "description": "Type of the ignition for ICE - spark = spark plug ignition, compression = self-igniting (Diesel engines)",
+                "type": "sensor"
+              },
+              "IsMILOn": {
+                "datatype": "boolean",
+                "deprecation": "v5.0 OBD-branch is deprecated.",
+                "description": "Malfunction Indicator Light (MIL) - False = Off, True = On",
+                "type": "sensor"
+              }
+            },
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 41 - OBD status for the current drive cycle",
+            "type": "branch"
+          },
+          "EGRError": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 2D - Exhaust gas recirculation (EGR) error",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "EVAPVaporPressure": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 32 - Evaporative purge (EVAP) system pressure",
+            "type": "sensor",
+            "unit": "Pa"
+          },
+          "EVAPVaporPressureAbsolute": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 53 - Absolute evaporative purge (EVAP) system pressure",
+            "type": "sensor",
+            "unit": "kPa"
+          },
+          "EVAPVaporPressureAlternate": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 54 - Alternate evaporative purge (EVAP) system pressure",
+            "type": "sensor",
+            "unit": "Pa"
+          },
+          "EngineLoad": {
+            "datatype": "float",
+            "dbc2vss": {
+              "interval_ms": 100,
+              "signal": "RearPower266",
+              "transform": {
+                "math": "floor(abs(x/5))"
+              }
+            },
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 04 - Engine load in percent - 0 = no load, 100 = full load",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "EngineSpeed": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 0C - Engine speed measured as rotations per minute",
+            "type": "sensor",
+            "unit": "rpm"
+          },
+          "EthanolPercent": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 52 - Percentage of ethanol in the fuel",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "FreezeDTC": {
+            "datatype": "string",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 02 - DTC that triggered the freeze frame",
+            "type": "sensor"
+          },
+          "FuelInjectionTiming": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 5D - Fuel injection timing",
+            "type": "sensor",
+            "unit": "degrees"
+          },
+          "FuelLevel": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 2F - Fuel level in the fuel tank",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "FuelPressure": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 0A - Fuel pressure",
+            "type": "sensor",
+            "unit": "kPa"
+          },
+          "FuelRailPressureAbsolute": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 59 - Absolute fuel rail pressure",
+            "type": "sensor",
+            "unit": "kPa"
+          },
+          "FuelRailPressureDirect": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 23 - Fuel rail pressure direct inject",
+            "type": "sensor",
+            "unit": "kPa"
+          },
+          "FuelRailPressureVac": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 22 - Fuel rail pressure relative to vacuum",
+            "type": "sensor",
+            "unit": "kPa"
+          },
+          "FuelRate": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 5E - Engine fuel rate",
+            "type": "sensor",
+            "unit": "l/h"
+          },
+          "FuelStatus": {
+            "datatype": "string",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 03 - Fuel status",
+            "type": "sensor"
+          },
+          "FuelType": {
+            "datatype": "uint8",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 51 - Fuel type",
+            "max": 23,
+            "min": 0,
+            "type": "attribute"
+          },
+          "HybridBatteryRemaining": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 5B - Remaining life of hybrid battery",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "IntakeTemp": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 0F - Intake temperature",
+            "type": "sensor",
+            "unit": "celsius"
+          },
+          "IsPTOActive": {
+            "datatype": "boolean",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 1E - Auxiliary input status (power take off)",
+            "type": "sensor"
+          },
+          "LongTermFuelTrim1": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 07 - Long Term (learned) Fuel Trim - Bank 1 - negative percent leaner, positive percent richer",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "LongTermFuelTrim2": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 09 - Long Term (learned) Fuel Trim - Bank 2 - negative percent leaner, positive percent richer",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "LongTermO2Trim1": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 56 (byte A) - Long term secondary O2 trim - Bank 1",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "LongTermO2Trim2": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 58 (byte A) - Long term secondary O2 trim - Bank 2",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "LongTermO2Trim3": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 56 (byte B) - Long term secondary O2 trim - Bank 3",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "LongTermO2Trim4": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 58 (byte B) - Long term secondary O2 trim - Bank 4",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "MAF": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 10 - Grams of air drawn into engine per second",
+            "type": "sensor",
+            "unit": "g/s"
+          },
+          "MAP": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 0B - Intake manifold pressure",
+            "type": "sensor",
+            "unit": "kPa"
+          },
+          "MaxMAF": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 50 - Maximum flow for mass air flow sensor",
+            "type": "sensor",
+            "unit": "g/s"
+          },
+          "O2": {
+            "children": {
+              "Sensor1": {
+                "children": {
+                  "ShortTermFuelTrim": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 1x (byte B) - Short term fuel trim",
+                    "type": "sensor",
+                    "unit": "percent"
+                  },
+                  "Voltage": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 1x (byte A) - Sensor voltage",
+                    "type": "sensor",
+                    "unit": "V"
+                  }
+                },
+                "description": "Oxygen sensors (PID 14 - PID 1B)",
+                "type": "branch"
+              },
+              "Sensor2": {
+                "children": {
+                  "ShortTermFuelTrim": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 1x (byte B) - Short term fuel trim",
+                    "type": "sensor",
+                    "unit": "percent"
+                  },
+                  "Voltage": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 1x (byte A) - Sensor voltage",
+                    "type": "sensor",
+                    "unit": "V"
+                  }
+                },
+                "description": "Oxygen sensors (PID 14 - PID 1B)",
+                "type": "branch"
+              },
+              "Sensor3": {
+                "children": {
+                  "ShortTermFuelTrim": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 1x (byte B) - Short term fuel trim",
+                    "type": "sensor",
+                    "unit": "percent"
+                  },
+                  "Voltage": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 1x (byte A) - Sensor voltage",
+                    "type": "sensor",
+                    "unit": "V"
+                  }
+                },
+                "description": "Oxygen sensors (PID 14 - PID 1B)",
+                "type": "branch"
+              },
+              "Sensor4": {
+                "children": {
+                  "ShortTermFuelTrim": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 1x (byte B) - Short term fuel trim",
+                    "type": "sensor",
+                    "unit": "percent"
+                  },
+                  "Voltage": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 1x (byte A) - Sensor voltage",
+                    "type": "sensor",
+                    "unit": "V"
+                  }
+                },
+                "description": "Oxygen sensors (PID 14 - PID 1B)",
+                "type": "branch"
+              },
+              "Sensor5": {
+                "children": {
+                  "ShortTermFuelTrim": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 1x (byte B) - Short term fuel trim",
+                    "type": "sensor",
+                    "unit": "percent"
+                  },
+                  "Voltage": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 1x (byte A) - Sensor voltage",
+                    "type": "sensor",
+                    "unit": "V"
+                  }
+                },
+                "description": "Oxygen sensors (PID 14 - PID 1B)",
+                "type": "branch"
+              },
+              "Sensor6": {
+                "children": {
+                  "ShortTermFuelTrim": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 1x (byte B) - Short term fuel trim",
+                    "type": "sensor",
+                    "unit": "percent"
+                  },
+                  "Voltage": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 1x (byte A) - Sensor voltage",
+                    "type": "sensor",
+                    "unit": "V"
+                  }
+                },
+                "description": "Oxygen sensors (PID 14 - PID 1B)",
+                "type": "branch"
+              },
+              "Sensor7": {
+                "children": {
+                  "ShortTermFuelTrim": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 1x (byte B) - Short term fuel trim",
+                    "type": "sensor",
+                    "unit": "percent"
+                  },
+                  "Voltage": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 1x (byte A) - Sensor voltage",
+                    "type": "sensor",
+                    "unit": "V"
+                  }
+                },
+                "description": "Oxygen sensors (PID 14 - PID 1B)",
+                "type": "branch"
+              },
+              "Sensor8": {
+                "children": {
+                  "ShortTermFuelTrim": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 1x (byte B) - Short term fuel trim",
+                    "type": "sensor",
+                    "unit": "percent"
+                  },
+                  "Voltage": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 1x (byte A) - Sensor voltage",
+                    "type": "sensor",
+                    "unit": "V"
+                  }
+                },
+                "description": "Oxygen sensors (PID 14 - PID 1B)",
+                "type": "branch"
+              }
+            },
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "Oxygen sensors (PID 14 - PID 1B)",
+            "type": "branch"
+          },
+          "O2WR": {
+            "children": {
+              "Sensor1": {
+                "children": {
+                  "Current": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 3x (byte CD) - Current for wide range/band oxygen sensor",
+                    "type": "sensor",
+                    "unit": "A"
+                  },
+                  "Lambda": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 2x (byte AB) and PID 3x (byte AB) - Lambda for wide range/band oxygen sensor",
+                    "type": "sensor"
+                  },
+                  "Voltage": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 2x (byte CD) - Voltage for wide range/band oxygen sensor",
+                    "type": "sensor",
+                    "unit": "V"
+                  }
+                },
+                "description": "Wide range/band oxygen sensors (PID 24 - 2B and PID 34 - 3B)",
+                "type": "branch"
+              },
+              "Sensor2": {
+                "children": {
+                  "Current": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 3x (byte CD) - Current for wide range/band oxygen sensor",
+                    "type": "sensor",
+                    "unit": "A"
+                  },
+                  "Lambda": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 2x (byte AB) and PID 3x (byte AB) - Lambda for wide range/band oxygen sensor",
+                    "type": "sensor"
+                  },
+                  "Voltage": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 2x (byte CD) - Voltage for wide range/band oxygen sensor",
+                    "type": "sensor",
+                    "unit": "V"
+                  }
+                },
+                "description": "Wide range/band oxygen sensors (PID 24 - 2B and PID 34 - 3B)",
+                "type": "branch"
+              },
+              "Sensor3": {
+                "children": {
+                  "Current": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 3x (byte CD) - Current for wide range/band oxygen sensor",
+                    "type": "sensor",
+                    "unit": "A"
+                  },
+                  "Lambda": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 2x (byte AB) and PID 3x (byte AB) - Lambda for wide range/band oxygen sensor",
+                    "type": "sensor"
+                  },
+                  "Voltage": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 2x (byte CD) - Voltage for wide range/band oxygen sensor",
+                    "type": "sensor",
+                    "unit": "V"
+                  }
+                },
+                "description": "Wide range/band oxygen sensors (PID 24 - 2B and PID 34 - 3B)",
+                "type": "branch"
+              },
+              "Sensor4": {
+                "children": {
+                  "Current": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 3x (byte CD) - Current for wide range/band oxygen sensor",
+                    "type": "sensor",
+                    "unit": "A"
+                  },
+                  "Lambda": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 2x (byte AB) and PID 3x (byte AB) - Lambda for wide range/band oxygen sensor",
+                    "type": "sensor"
+                  },
+                  "Voltage": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 2x (byte CD) - Voltage for wide range/band oxygen sensor",
+                    "type": "sensor",
+                    "unit": "V"
+                  }
+                },
+                "description": "Wide range/band oxygen sensors (PID 24 - 2B and PID 34 - 3B)",
+                "type": "branch"
+              },
+              "Sensor5": {
+                "children": {
+                  "Current": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 3x (byte CD) - Current for wide range/band oxygen sensor",
+                    "type": "sensor",
+                    "unit": "A"
+                  },
+                  "Lambda": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 2x (byte AB) and PID 3x (byte AB) - Lambda for wide range/band oxygen sensor",
+                    "type": "sensor"
+                  },
+                  "Voltage": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 2x (byte CD) - Voltage for wide range/band oxygen sensor",
+                    "type": "sensor",
+                    "unit": "V"
+                  }
+                },
+                "description": "Wide range/band oxygen sensors (PID 24 - 2B and PID 34 - 3B)",
+                "type": "branch"
+              },
+              "Sensor6": {
+                "children": {
+                  "Current": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 3x (byte CD) - Current for wide range/band oxygen sensor",
+                    "type": "sensor",
+                    "unit": "A"
+                  },
+                  "Lambda": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 2x (byte AB) and PID 3x (byte AB) - Lambda for wide range/band oxygen sensor",
+                    "type": "sensor"
+                  },
+                  "Voltage": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 2x (byte CD) - Voltage for wide range/band oxygen sensor",
+                    "type": "sensor",
+                    "unit": "V"
+                  }
+                },
+                "description": "Wide range/band oxygen sensors (PID 24 - 2B and PID 34 - 3B)",
+                "type": "branch"
+              },
+              "Sensor7": {
+                "children": {
+                  "Current": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 3x (byte CD) - Current for wide range/band oxygen sensor",
+                    "type": "sensor",
+                    "unit": "A"
+                  },
+                  "Lambda": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 2x (byte AB) and PID 3x (byte AB) - Lambda for wide range/band oxygen sensor",
+                    "type": "sensor"
+                  },
+                  "Voltage": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 2x (byte CD) - Voltage for wide range/band oxygen sensor",
+                    "type": "sensor",
+                    "unit": "V"
+                  }
+                },
+                "description": "Wide range/band oxygen sensors (PID 24 - 2B and PID 34 - 3B)",
+                "type": "branch"
+              },
+              "Sensor8": {
+                "children": {
+                  "Current": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 3x (byte CD) - Current for wide range/band oxygen sensor",
+                    "type": "sensor",
+                    "unit": "A"
+                  },
+                  "Lambda": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 2x (byte AB) and PID 3x (byte AB) - Lambda for wide range/band oxygen sensor",
+                    "type": "sensor"
+                  },
+                  "Voltage": {
+                    "datatype": "float",
+                    "deprecation": "v5.0 OBD-branch is deprecated.",
+                    "description": "PID 2x (byte CD) - Voltage for wide range/band oxygen sensor",
+                    "type": "sensor",
+                    "unit": "V"
+                  }
+                },
+                "description": "Wide range/band oxygen sensors (PID 24 - 2B and PID 34 - 3B)",
+                "type": "branch"
+              }
+            },
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "Wide range/band oxygen sensors (PID 24 - 2B and PID 34 - 3B)",
+            "type": "branch"
+          },
+          "OBDStandards": {
+            "datatype": "uint8",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 1C - OBD standards this vehicle conforms to",
+            "type": "attribute"
+          },
+          "OilTemperature": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 5C - Engine oil temperature",
+            "type": "sensor",
+            "unit": "celsius"
+          },
+          "OxygenSensorsIn2Banks": {
+            "datatype": "uint8",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 13 - Presence of oxygen sensors in 2 banks. [A0..A3] == Bank 1, Sensors 1-4. [A4..A7] == Bank 2, Sensors 1-4",
+            "type": "sensor"
+          },
+          "OxygenSensorsIn4Banks": {
+            "datatype": "uint8",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 1D - Presence of oxygen sensors in 4 banks. Similar to PID 13, but [A0..A7] == [B1S1, B1S2, B2S1, B2S2, B3S1, B3S2, B4S1, B4S2]",
+            "type": "sensor"
+          },
+          "PidsA": {
+            "allowed": [
+              "01",
+              "02",
+              "03",
+              "04",
+              "05",
+              "06",
+              "07",
+              "08",
+              "09",
+              "0A",
+              "0B",
+              "0C",
+              "0D",
+              "0E",
+              "0F",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "1A",
+              "1B",
+              "1C",
+              "1D",
+              "1E",
+              "1F",
+              "20"
+            ],
+            "datatype": "string[]",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 00 - Array of the supported PIDs 01 to 20 in Hexadecimal.",
+            "type": "attribute"
+          },
+          "PidsB": {
+            "allowed": [
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "2A",
+              "2B",
+              "2C",
+              "2D",
+              "2E",
+              "2F",
+              "30",
+              "31",
+              "32",
+              "33",
+              "34",
+              "35",
+              "36",
+              "37",
+              "38",
+              "39",
+              "3A",
+              "3B",
+              "3C",
+              "3D",
+              "3E",
+              "3F",
+              "40"
+            ],
+            "datatype": "string[]",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 20 - Array of the supported PIDs 21 to 40 in Hexadecimal.",
+            "type": "attribute"
+          },
+          "PidsC": {
+            "allowed": [
+              "41",
+              "42",
+              "43",
+              "44",
+              "45",
+              "46",
+              "47",
+              "48",
+              "49",
+              "4A",
+              "4B",
+              "4C",
+              "4D",
+              "4E",
+              "4F",
+              "50",
+              "51",
+              "52",
+              "53",
+              "54",
+              "55",
+              "56",
+              "57",
+              "58",
+              "59",
+              "5A",
+              "5B",
+              "5C",
+              "5D",
+              "5E",
+              "5F",
+              "60"
+            ],
+            "datatype": "string[]",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 40 - Array of the supported PIDs 41 to 60 in Hexadecimal.",
+            "type": "attribute"
+          },
+          "RelativeAcceleratorPosition": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 5A - Relative accelerator pedal position",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "RelativeThrottlePosition": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 45 - Relative throttle position",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "RunTime": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 1F - Engine run time",
+            "type": "sensor",
+            "unit": "s"
+          },
+          "RunTimeMIL": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 4D - Run time with MIL on",
+            "type": "sensor",
+            "unit": "min"
+          },
+          "ShortTermFuelTrim1": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 06 - Short Term (immediate) Fuel Trim - Bank 1 - negative percent leaner, positive percent richer",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "ShortTermFuelTrim2": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 08 - Short Term (immediate) Fuel Trim - Bank 2 - negative percent leaner, positive percent richer",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "ShortTermO2Trim1": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 55 (byte A) - Short term secondary O2 trim - Bank 1",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "ShortTermO2Trim2": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 57 (byte A) - Short term secondary O2 trim - Bank 2",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "ShortTermO2Trim3": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 55 (byte B) - Short term secondary O2 trim - Bank 3",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "ShortTermO2Trim4": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 57 (byte B) - Short term secondary O2 trim - Bank 4",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "Speed": {
+            "datatype": "float",
+            "dbc2vss": {
+              "interval_ms": 100,
+              "signal": "DI_uiSpeed"
+            },
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 0D - Vehicle speed",
+            "type": "sensor",
+            "unit": "km/h"
+          },
+          "Status": {
+            "children": {
+              "DTCCount": {
+                "datatype": "uint8",
+                "deprecation": "v5.0 replaced with Vehicle.Diagnostics.DTCCount",
+                "description": "Number of Diagnostic Trouble Codes (DTC)",
+                "type": "sensor"
+              },
+              "IgnitionType": {
+                "allowed": [
+                  "SPARK",
+                  "COMPRESSION"
+                ],
+                "datatype": "string",
+                "deprecation": "v5.0 OBD-branch is deprecated.",
+                "description": "Type of the ignition for ICE - spark = spark plug ignition, compression = self-igniting (Diesel engines)",
+                "type": "attribute"
+              },
+              "IsMILOn": {
+                "datatype": "boolean",
+                "deprecation": "v5.0 OBD-branch is deprecated.",
+                "description": "Malfunction Indicator Light (MIL) False = Off, True = On",
+                "type": "sensor"
+              }
+            },
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 01 - OBD status",
+            "type": "branch"
+          },
+          "ThrottleActuator": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 4C - Commanded throttle actuator",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "ThrottlePosition": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 11 - Throttle position - 0 = closed throttle, 100 = open throttle",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "ThrottlePositionB": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 47 - Absolute throttle position B",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "ThrottlePositionC": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 48 - Absolute throttle position C",
+            "type": "sensor",
+            "unit": "percent"
+          },
+          "TimeSinceDTCCleared": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 4E - Time since trouble codes cleared",
+            "type": "sensor",
+            "unit": "min"
+          },
+          "TimingAdvance": {
+            "datatype": "float",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 0E - Time advance",
+            "type": "sensor",
+            "unit": "degrees"
+          },
+          "WarmupsSinceDTCClear": {
+            "datatype": "uint8",
+            "deprecation": "v5.0 OBD-branch is deprecated.",
+            "description": "PID 30 - Number of warm-ups since codes cleared",
+            "type": "sensor"
+          }
+        },
+        "description": "OBD data.",
+        "type": "branch"
+      },
+      "Occupant": {
+        "children": {
+          "Row1": {
+            "children": {
+              "DriverSide": {
+                "children": {
+                  "HeadPosition": {
+                    "children": {
+                      "Pitch": {
+                        "datatype": "float",
+                        "description": "Head pitch angle, measured as angle from vehicle sprung mass XY-plane as defined by ISO 23150:2023 to the head X-axis. 0 = Head in normal position. Positive values = Head leaning up. Negative values = Head leaning down.",
+                        "max": 90,
+                        "min": -90,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "Roll": {
+                        "datatype": "float",
+                        "description": "Head roll angle about the head X-axis (right-hand rule). 0 = Head in normal position. Positive values = Head leaning to the right. Negative values = Head leaning to the left.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "X": {
+                        "datatype": "int16",
+                        "description": "Longitudinal position of head center measured as mid eye position on X-axis of the vehicle rear-axle coordinate system as defined by ISO 23150:2023 section 3.7.12 Mid eye position refers to the center of a line drawn between the center of the drivers eyes. Positive values = forward of (first) rear-axle. Negative values = backward of (first) rear-axle.",
+                        "type": "sensor",
+                        "unit": "mm"
+                      },
+                      "Y": {
+                        "datatype": "int16",
+                        "description": "Lateral position of head center measured as mid eye position on X-axis of the vehicle rear-axle coordinate system as defined by ISO 23150:2023 section 3.7.12 Mid eye position refers to the center of a line drawn between the center of the drivers eyes. Positive values = left of rear-axle center. Negative values = right of rear-axle center.",
+                        "type": "sensor",
+                        "unit": "mm"
+                      },
+                      "Yaw": {
+                        "datatype": "float",
+                        "description": "Head yaw angle, measured from the vehicle sprung mass X-axis as defined by ISO 23150:2023 to the head X-axis, around the vehicle Z-axis (right-hand rule). 0 = Head in normal position. Positive values = Head turned left. Negative values = Head turned right.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "Z": {
+                        "datatype": "int16",
+                        "description": "Height position of head center measured as mid eye position on X-axis of the vehicle rear-axle coordinate system as defined by ISO 23150:2023 section 3.7.12 Mid eye position refers to the center of a line drawn between the center of the drivers eyes. Positive values = above center of rear-axle reference point. Negative values = below center of rear-axle reference point.",
+                        "type": "sensor",
+                        "unit": "mm"
+                      }
+                    },
+                    "description": "The current position of the driver head on vehicle axis according to ISO 23150:2023.",
+                    "type": "branch"
+                  },
+                  "Identifier": {
+                    "children": {
+                      "Issuer": {
+                        "datatype": "string",
+                        "description": "Unique Issuer for the authentication of the occupant e.g. https://accounts.funcorp.com.",
+                        "type": "sensor"
+                      },
+                      "Subject": {
+                        "datatype": "string",
+                        "description": "Subject for the authentication of the occupant e.g. UserID 7331677.",
+                        "type": "sensor"
+                      }
+                    },
+                    "description": "Identifier attributes based on OAuth 2.0.",
+                    "type": "branch"
+                  },
+                  "MidEyeGaze": {
+                    "children": {
+                      "Azimuth": {
+                        "datatype": "float",
+                        "description": "Mid eye azimuth gaze (right-hand rule) on vehicle sprung mass Z-axis as defined by ISO 23150:2023 0 = Driver looking forward. Positive values = Driver looking at something on the left side of driver. Negative values = Driver looking at something on the right side of driver.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "Elevation": {
+                        "datatype": "float",
+                        "description": "Elevation to observed object measured as angle between vehicle sprung mass XY-plane as defined by ISO 23150:2023 at driver mid eye position and object. 0 = Driver looking at something at same height as mid eye position. Positive values = Driver looking at something above mid eye position. Negative values = Driver looking at something below mid eye position.",
+                        "max": 90,
+                        "min": -90,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      }
+                    },
+                    "description": "Direction from mid eye position to object driver is looking at.",
+                    "type": "branch"
+                  }
+                },
+                "description": "Occupant (Driver or Passenger) data.",
+                "type": "branch"
+              },
+              "Middle": {
+                "children": {
+                  "HeadPosition": {
+                    "children": {
+                      "Pitch": {
+                        "datatype": "float",
+                        "description": "Head pitch angle, measured as angle from vehicle sprung mass XY-plane as defined by ISO 23150:2023 to the head X-axis. 0 = Head in normal position. Positive values = Head leaning up. Negative values = Head leaning down.",
+                        "max": 90,
+                        "min": -90,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "Roll": {
+                        "datatype": "float",
+                        "description": "Head roll angle about the head X-axis (right-hand rule). 0 = Head in normal position. Positive values = Head leaning to the right. Negative values = Head leaning to the left.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "X": {
+                        "datatype": "int16",
+                        "description": "Longitudinal position of head center measured as mid eye position on X-axis of the vehicle rear-axle coordinate system as defined by ISO 23150:2023 section 3.7.12 Mid eye position refers to the center of a line drawn between the center of the drivers eyes. Positive values = forward of (first) rear-axle. Negative values = backward of (first) rear-axle.",
+                        "type": "sensor",
+                        "unit": "mm"
+                      },
+                      "Y": {
+                        "datatype": "int16",
+                        "description": "Lateral position of head center measured as mid eye position on X-axis of the vehicle rear-axle coordinate system as defined by ISO 23150:2023 section 3.7.12 Mid eye position refers to the center of a line drawn between the center of the drivers eyes. Positive values = left of rear-axle center. Negative values = right of rear-axle center.",
+                        "type": "sensor",
+                        "unit": "mm"
+                      },
+                      "Yaw": {
+                        "datatype": "float",
+                        "description": "Head yaw angle, measured from the vehicle sprung mass X-axis as defined by ISO 23150:2023 to the head X-axis, around the vehicle Z-axis (right-hand rule). 0 = Head in normal position. Positive values = Head turned left. Negative values = Head turned right.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "Z": {
+                        "datatype": "int16",
+                        "description": "Height position of head center measured as mid eye position on X-axis of the vehicle rear-axle coordinate system as defined by ISO 23150:2023 section 3.7.12 Mid eye position refers to the center of a line drawn between the center of the drivers eyes. Positive values = above center of rear-axle reference point. Negative values = below center of rear-axle reference point.",
+                        "type": "sensor",
+                        "unit": "mm"
+                      }
+                    },
+                    "description": "The current position of the driver head on vehicle axis according to ISO 23150:2023.",
+                    "type": "branch"
+                  },
+                  "Identifier": {
+                    "children": {
+                      "Issuer": {
+                        "datatype": "string",
+                        "description": "Unique Issuer for the authentication of the occupant e.g. https://accounts.funcorp.com.",
+                        "type": "sensor"
+                      },
+                      "Subject": {
+                        "datatype": "string",
+                        "description": "Subject for the authentication of the occupant e.g. UserID 7331677.",
+                        "type": "sensor"
+                      }
+                    },
+                    "description": "Identifier attributes based on OAuth 2.0.",
+                    "type": "branch"
+                  },
+                  "MidEyeGaze": {
+                    "children": {
+                      "Azimuth": {
+                        "datatype": "float",
+                        "description": "Mid eye azimuth gaze (right-hand rule) on vehicle sprung mass Z-axis as defined by ISO 23150:2023 0 = Driver looking forward. Positive values = Driver looking at something on the left side of driver. Negative values = Driver looking at something on the right side of driver.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "Elevation": {
+                        "datatype": "float",
+                        "description": "Elevation to observed object measured as angle between vehicle sprung mass XY-plane as defined by ISO 23150:2023 at driver mid eye position and object. 0 = Driver looking at something at same height as mid eye position. Positive values = Driver looking at something above mid eye position. Negative values = Driver looking at something below mid eye position.",
+                        "max": 90,
+                        "min": -90,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      }
+                    },
+                    "description": "Direction from mid eye position to object driver is looking at.",
+                    "type": "branch"
+                  }
+                },
+                "description": "Occupant (Driver or Passenger) data.",
+                "type": "branch"
+              },
+              "PassengerSide": {
+                "children": {
+                  "HeadPosition": {
+                    "children": {
+                      "Pitch": {
+                        "datatype": "float",
+                        "description": "Head pitch angle, measured as angle from vehicle sprung mass XY-plane as defined by ISO 23150:2023 to the head X-axis. 0 = Head in normal position. Positive values = Head leaning up. Negative values = Head leaning down.",
+                        "max": 90,
+                        "min": -90,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "Roll": {
+                        "datatype": "float",
+                        "description": "Head roll angle about the head X-axis (right-hand rule). 0 = Head in normal position. Positive values = Head leaning to the right. Negative values = Head leaning to the left.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "X": {
+                        "datatype": "int16",
+                        "description": "Longitudinal position of head center measured as mid eye position on X-axis of the vehicle rear-axle coordinate system as defined by ISO 23150:2023 section 3.7.12 Mid eye position refers to the center of a line drawn between the center of the drivers eyes. Positive values = forward of (first) rear-axle. Negative values = backward of (first) rear-axle.",
+                        "type": "sensor",
+                        "unit": "mm"
+                      },
+                      "Y": {
+                        "datatype": "int16",
+                        "description": "Lateral position of head center measured as mid eye position on X-axis of the vehicle rear-axle coordinate system as defined by ISO 23150:2023 section 3.7.12 Mid eye position refers to the center of a line drawn between the center of the drivers eyes. Positive values = left of rear-axle center. Negative values = right of rear-axle center.",
+                        "type": "sensor",
+                        "unit": "mm"
+                      },
+                      "Yaw": {
+                        "datatype": "float",
+                        "description": "Head yaw angle, measured from the vehicle sprung mass X-axis as defined by ISO 23150:2023 to the head X-axis, around the vehicle Z-axis (right-hand rule). 0 = Head in normal position. Positive values = Head turned left. Negative values = Head turned right.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "Z": {
+                        "datatype": "int16",
+                        "description": "Height position of head center measured as mid eye position on X-axis of the vehicle rear-axle coordinate system as defined by ISO 23150:2023 section 3.7.12 Mid eye position refers to the center of a line drawn between the center of the drivers eyes. Positive values = above center of rear-axle reference point. Negative values = below center of rear-axle reference point.",
+                        "type": "sensor",
+                        "unit": "mm"
+                      }
+                    },
+                    "description": "The current position of the driver head on vehicle axis according to ISO 23150:2023.",
+                    "type": "branch"
+                  },
+                  "Identifier": {
+                    "children": {
+                      "Issuer": {
+                        "datatype": "string",
+                        "description": "Unique Issuer for the authentication of the occupant e.g. https://accounts.funcorp.com.",
+                        "type": "sensor"
+                      },
+                      "Subject": {
+                        "datatype": "string",
+                        "description": "Subject for the authentication of the occupant e.g. UserID 7331677.",
+                        "type": "sensor"
+                      }
+                    },
+                    "description": "Identifier attributes based on OAuth 2.0.",
+                    "type": "branch"
+                  },
+                  "MidEyeGaze": {
+                    "children": {
+                      "Azimuth": {
+                        "datatype": "float",
+                        "description": "Mid eye azimuth gaze (right-hand rule) on vehicle sprung mass Z-axis as defined by ISO 23150:2023 0 = Driver looking forward. Positive values = Driver looking at something on the left side of driver. Negative values = Driver looking at something on the right side of driver.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "Elevation": {
+                        "datatype": "float",
+                        "description": "Elevation to observed object measured as angle between vehicle sprung mass XY-plane as defined by ISO 23150:2023 at driver mid eye position and object. 0 = Driver looking at something at same height as mid eye position. Positive values = Driver looking at something above mid eye position. Negative values = Driver looking at something below mid eye position.",
+                        "max": 90,
+                        "min": -90,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      }
+                    },
+                    "description": "Direction from mid eye position to object driver is looking at.",
+                    "type": "branch"
+                  }
+                },
+                "description": "Occupant (Driver or Passenger) data.",
+                "type": "branch"
+              }
+            },
+            "description": "Occupant (Driver or Passenger) data.",
+            "type": "branch"
+          },
+          "Row2": {
+            "children": {
+              "DriverSide": {
+                "children": {
+                  "HeadPosition": {
+                    "children": {
+                      "Pitch": {
+                        "datatype": "float",
+                        "description": "Head pitch angle, measured as angle from vehicle sprung mass XY-plane as defined by ISO 23150:2023 to the head X-axis. 0 = Head in normal position. Positive values = Head leaning up. Negative values = Head leaning down.",
+                        "max": 90,
+                        "min": -90,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "Roll": {
+                        "datatype": "float",
+                        "description": "Head roll angle about the head X-axis (right-hand rule). 0 = Head in normal position. Positive values = Head leaning to the right. Negative values = Head leaning to the left.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "X": {
+                        "datatype": "int16",
+                        "description": "Longitudinal position of head center measured as mid eye position on X-axis of the vehicle rear-axle coordinate system as defined by ISO 23150:2023 section 3.7.12 Mid eye position refers to the center of a line drawn between the center of the drivers eyes. Positive values = forward of (first) rear-axle. Negative values = backward of (first) rear-axle.",
+                        "type": "sensor",
+                        "unit": "mm"
+                      },
+                      "Y": {
+                        "datatype": "int16",
+                        "description": "Lateral position of head center measured as mid eye position on X-axis of the vehicle rear-axle coordinate system as defined by ISO 23150:2023 section 3.7.12 Mid eye position refers to the center of a line drawn between the center of the drivers eyes. Positive values = left of rear-axle center. Negative values = right of rear-axle center.",
+                        "type": "sensor",
+                        "unit": "mm"
+                      },
+                      "Yaw": {
+                        "datatype": "float",
+                        "description": "Head yaw angle, measured from the vehicle sprung mass X-axis as defined by ISO 23150:2023 to the head X-axis, around the vehicle Z-axis (right-hand rule). 0 = Head in normal position. Positive values = Head turned left. Negative values = Head turned right.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "Z": {
+                        "datatype": "int16",
+                        "description": "Height position of head center measured as mid eye position on X-axis of the vehicle rear-axle coordinate system as defined by ISO 23150:2023 section 3.7.12 Mid eye position refers to the center of a line drawn between the center of the drivers eyes. Positive values = above center of rear-axle reference point. Negative values = below center of rear-axle reference point.",
+                        "type": "sensor",
+                        "unit": "mm"
+                      }
+                    },
+                    "description": "The current position of the driver head on vehicle axis according to ISO 23150:2023.",
+                    "type": "branch"
+                  },
+                  "Identifier": {
+                    "children": {
+                      "Issuer": {
+                        "datatype": "string",
+                        "description": "Unique Issuer for the authentication of the occupant e.g. https://accounts.funcorp.com.",
+                        "type": "sensor"
+                      },
+                      "Subject": {
+                        "datatype": "string",
+                        "description": "Subject for the authentication of the occupant e.g. UserID 7331677.",
+                        "type": "sensor"
+                      }
+                    },
+                    "description": "Identifier attributes based on OAuth 2.0.",
+                    "type": "branch"
+                  },
+                  "MidEyeGaze": {
+                    "children": {
+                      "Azimuth": {
+                        "datatype": "float",
+                        "description": "Mid eye azimuth gaze (right-hand rule) on vehicle sprung mass Z-axis as defined by ISO 23150:2023 0 = Driver looking forward. Positive values = Driver looking at something on the left side of driver. Negative values = Driver looking at something on the right side of driver.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "Elevation": {
+                        "datatype": "float",
+                        "description": "Elevation to observed object measured as angle between vehicle sprung mass XY-plane as defined by ISO 23150:2023 at driver mid eye position and object. 0 = Driver looking at something at same height as mid eye position. Positive values = Driver looking at something above mid eye position. Negative values = Driver looking at something below mid eye position.",
+                        "max": 90,
+                        "min": -90,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      }
+                    },
+                    "description": "Direction from mid eye position to object driver is looking at.",
+                    "type": "branch"
+                  }
+                },
+                "description": "Occupant (Driver or Passenger) data.",
+                "type": "branch"
+              },
+              "Middle": {
+                "children": {
+                  "HeadPosition": {
+                    "children": {
+                      "Pitch": {
+                        "datatype": "float",
+                        "description": "Head pitch angle, measured as angle from vehicle sprung mass XY-plane as defined by ISO 23150:2023 to the head X-axis. 0 = Head in normal position. Positive values = Head leaning up. Negative values = Head leaning down.",
+                        "max": 90,
+                        "min": -90,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "Roll": {
+                        "datatype": "float",
+                        "description": "Head roll angle about the head X-axis (right-hand rule). 0 = Head in normal position. Positive values = Head leaning to the right. Negative values = Head leaning to the left.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "X": {
+                        "datatype": "int16",
+                        "description": "Longitudinal position of head center measured as mid eye position on X-axis of the vehicle rear-axle coordinate system as defined by ISO 23150:2023 section 3.7.12 Mid eye position refers to the center of a line drawn between the center of the drivers eyes. Positive values = forward of (first) rear-axle. Negative values = backward of (first) rear-axle.",
+                        "type": "sensor",
+                        "unit": "mm"
+                      },
+                      "Y": {
+                        "datatype": "int16",
+                        "description": "Lateral position of head center measured as mid eye position on X-axis of the vehicle rear-axle coordinate system as defined by ISO 23150:2023 section 3.7.12 Mid eye position refers to the center of a line drawn between the center of the drivers eyes. Positive values = left of rear-axle center. Negative values = right of rear-axle center.",
+                        "type": "sensor",
+                        "unit": "mm"
+                      },
+                      "Yaw": {
+                        "datatype": "float",
+                        "description": "Head yaw angle, measured from the vehicle sprung mass X-axis as defined by ISO 23150:2023 to the head X-axis, around the vehicle Z-axis (right-hand rule). 0 = Head in normal position. Positive values = Head turned left. Negative values = Head turned right.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "Z": {
+                        "datatype": "int16",
+                        "description": "Height position of head center measured as mid eye position on X-axis of the vehicle rear-axle coordinate system as defined by ISO 23150:2023 section 3.7.12 Mid eye position refers to the center of a line drawn between the center of the drivers eyes. Positive values = above center of rear-axle reference point. Negative values = below center of rear-axle reference point.",
+                        "type": "sensor",
+                        "unit": "mm"
+                      }
+                    },
+                    "description": "The current position of the driver head on vehicle axis according to ISO 23150:2023.",
+                    "type": "branch"
+                  },
+                  "Identifier": {
+                    "children": {
+                      "Issuer": {
+                        "datatype": "string",
+                        "description": "Unique Issuer for the authentication of the occupant e.g. https://accounts.funcorp.com.",
+                        "type": "sensor"
+                      },
+                      "Subject": {
+                        "datatype": "string",
+                        "description": "Subject for the authentication of the occupant e.g. UserID 7331677.",
+                        "type": "sensor"
+                      }
+                    },
+                    "description": "Identifier attributes based on OAuth 2.0.",
+                    "type": "branch"
+                  },
+                  "MidEyeGaze": {
+                    "children": {
+                      "Azimuth": {
+                        "datatype": "float",
+                        "description": "Mid eye azimuth gaze (right-hand rule) on vehicle sprung mass Z-axis as defined by ISO 23150:2023 0 = Driver looking forward. Positive values = Driver looking at something on the left side of driver. Negative values = Driver looking at something on the right side of driver.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "Elevation": {
+                        "datatype": "float",
+                        "description": "Elevation to observed object measured as angle between vehicle sprung mass XY-plane as defined by ISO 23150:2023 at driver mid eye position and object. 0 = Driver looking at something at same height as mid eye position. Positive values = Driver looking at something above mid eye position. Negative values = Driver looking at something below mid eye position.",
+                        "max": 90,
+                        "min": -90,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      }
+                    },
+                    "description": "Direction from mid eye position to object driver is looking at.",
+                    "type": "branch"
+                  }
+                },
+                "description": "Occupant (Driver or Passenger) data.",
+                "type": "branch"
+              },
+              "PassengerSide": {
+                "children": {
+                  "HeadPosition": {
+                    "children": {
+                      "Pitch": {
+                        "datatype": "float",
+                        "description": "Head pitch angle, measured as angle from vehicle sprung mass XY-plane as defined by ISO 23150:2023 to the head X-axis. 0 = Head in normal position. Positive values = Head leaning up. Negative values = Head leaning down.",
+                        "max": 90,
+                        "min": -90,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "Roll": {
+                        "datatype": "float",
+                        "description": "Head roll angle about the head X-axis (right-hand rule). 0 = Head in normal position. Positive values = Head leaning to the right. Negative values = Head leaning to the left.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "X": {
+                        "datatype": "int16",
+                        "description": "Longitudinal position of head center measured as mid eye position on X-axis of the vehicle rear-axle coordinate system as defined by ISO 23150:2023 section 3.7.12 Mid eye position refers to the center of a line drawn between the center of the drivers eyes. Positive values = forward of (first) rear-axle. Negative values = backward of (first) rear-axle.",
+                        "type": "sensor",
+                        "unit": "mm"
+                      },
+                      "Y": {
+                        "datatype": "int16",
+                        "description": "Lateral position of head center measured as mid eye position on X-axis of the vehicle rear-axle coordinate system as defined by ISO 23150:2023 section 3.7.12 Mid eye position refers to the center of a line drawn between the center of the drivers eyes. Positive values = left of rear-axle center. Negative values = right of rear-axle center.",
+                        "type": "sensor",
+                        "unit": "mm"
+                      },
+                      "Yaw": {
+                        "datatype": "float",
+                        "description": "Head yaw angle, measured from the vehicle sprung mass X-axis as defined by ISO 23150:2023 to the head X-axis, around the vehicle Z-axis (right-hand rule). 0 = Head in normal position. Positive values = Head turned left. Negative values = Head turned right.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "Z": {
+                        "datatype": "int16",
+                        "description": "Height position of head center measured as mid eye position on X-axis of the vehicle rear-axle coordinate system as defined by ISO 23150:2023 section 3.7.12 Mid eye position refers to the center of a line drawn between the center of the drivers eyes. Positive values = above center of rear-axle reference point. Negative values = below center of rear-axle reference point.",
+                        "type": "sensor",
+                        "unit": "mm"
+                      }
+                    },
+                    "description": "The current position of the driver head on vehicle axis according to ISO 23150:2023.",
+                    "type": "branch"
+                  },
+                  "Identifier": {
+                    "children": {
+                      "Issuer": {
+                        "datatype": "string",
+                        "description": "Unique Issuer for the authentication of the occupant e.g. https://accounts.funcorp.com.",
+                        "type": "sensor"
+                      },
+                      "Subject": {
+                        "datatype": "string",
+                        "description": "Subject for the authentication of the occupant e.g. UserID 7331677.",
+                        "type": "sensor"
+                      }
+                    },
+                    "description": "Identifier attributes based on OAuth 2.0.",
+                    "type": "branch"
+                  },
+                  "MidEyeGaze": {
+                    "children": {
+                      "Azimuth": {
+                        "datatype": "float",
+                        "description": "Mid eye azimuth gaze (right-hand rule) on vehicle sprung mass Z-axis as defined by ISO 23150:2023 0 = Driver looking forward. Positive values = Driver looking at something on the left side of driver. Negative values = Driver looking at something on the right side of driver.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "Elevation": {
+                        "datatype": "float",
+                        "description": "Elevation to observed object measured as angle between vehicle sprung mass XY-plane as defined by ISO 23150:2023 at driver mid eye position and object. 0 = Driver looking at something at same height as mid eye position. Positive values = Driver looking at something above mid eye position. Negative values = Driver looking at something below mid eye position.",
+                        "max": 90,
+                        "min": -90,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      }
+                    },
+                    "description": "Direction from mid eye position to object driver is looking at.",
+                    "type": "branch"
+                  }
+                },
+                "description": "Occupant (Driver or Passenger) data.",
+                "type": "branch"
+              }
+            },
+            "description": "Occupant (Driver or Passenger) data.",
+            "type": "branch"
+          }
+        },
+        "description": "Occupant (Driver or Passenger) data.",
+        "type": "branch"
+      },
+      "PowerOptimizeLevel": {
+        "datatype": "uint8",
+        "description": "Power optimization level for this branch/subsystem. A higher number indicates more aggressive power optimization. Level 0 indicates that all functionality is enabled, no power optimization enabled. Level 10 indicates most aggressive power optimization mode, only essential functionality enabled.",
+        "max": 10,
+        "min": 0,
+        "type": "actuator"
+      },
+      "Powertrain": {
+        "children": {
+          "AccumulatedBrakingEnergy": {
+            "datatype": "float",
+            "description": "The accumulated energy from regenerative braking over lifetime.",
+            "type": "sensor",
+            "unit": "kWh"
+          },
+          "CombustionEngine": {
+            "children": {
+              "AspirationType": {
+                "allowed": [
+                  "UNKNOWN",
+                  "NATURAL",
+                  "SUPERCHARGER",
+                  "TURBOCHARGER"
+                ],
+                "datatype": "string",
+                "default": "UNKNOWN",
+                "description": "Type of aspiration (natural, turbocharger, supercharger etc).",
+                "type": "attribute"
+              },
+              "Bore": {
+                "datatype": "float",
+                "description": "Bore in millimetres.",
+                "type": "attribute",
+                "unit": "mm"
+              },
+              "CompressionRatio": {
+                "datatype": "string",
+                "description": "Engine compression ratio, specified in the format 'X:1', e.g. '9.2:1'.",
+                "type": "attribute"
+              },
+              "Configuration": {
+                "allowed": [
+                  "UNKNOWN",
+                  "STRAIGHT",
+                  "V",
+                  "BOXER",
+                  "W",
+                  "ROTARY",
+                  "RADIAL",
+                  "SQUARE",
+                  "H",
+                  "U",
+                  "OPPOSED",
+                  "X"
+                ],
+                "datatype": "string",
+                "default": "UNKNOWN",
+                "description": "Engine configuration.",
+                "type": "attribute"
+              },
+              "DieselExhaustFluid": {
+                "children": {
+                  "Capacity": {
+                    "datatype": "float",
+                    "description": "Capacity in liters of the Diesel Exhaust Fluid Tank.",
+                    "type": "attribute",
+                    "unit": "l"
+                  },
+                  "IsLevelLow": {
+                    "datatype": "boolean",
+                    "description": "Indicates if the Diesel Exhaust Fluid level is low. True if level is low. Definition of low is vehicle dependent.",
+                    "type": "sensor"
+                  },
+                  "Level": {
+                    "datatype": "uint8",
+                    "description": "Level of the Diesel Exhaust Fluid tank as percent of capacity. 0 = empty. 100 = full.",
+                    "max": 100,
+                    "min": 0,
+                    "type": "sensor",
+                    "unit": "percent"
+                  },
+                  "Range": {
+                    "datatype": "uint32",
+                    "description": "Remaining range in meters of the Diesel Exhaust Fluid present in the vehicle.",
+                    "type": "sensor",
+                    "unit": "m"
+                  }
+                },
+                "comment": "In retail and marketing other names are typically used for the fluid.",
+                "description": "Signals related to Diesel Exhaust Fluid (DEF). DEF is called AUS32 in ISO 22241.",
+                "type": "branch"
+              },
+              "DieselParticulateFilter": {
+                "children": {
+                  "DeltaPressure": {
+                    "datatype": "float",
+                    "description": "Delta Pressure of Diesel Particulate Filter.",
+                    "type": "sensor",
+                    "unit": "Pa"
+                  },
+                  "InletTemperature": {
+                    "datatype": "float",
+                    "description": "Inlet temperature of Diesel Particulate Filter.",
+                    "type": "sensor",
+                    "unit": "celsius"
+                  },
+                  "OutletTemperature": {
+                    "datatype": "float",
+                    "description": "Outlet temperature of Diesel Particulate Filter.",
+                    "type": "sensor",
+                    "unit": "celsius"
+                  }
+                },
+                "description": "Diesel Particulate Filter signals.",
+                "type": "branch"
+              },
+              "Displacement": {
+                "datatype": "uint16",
+                "description": "Displacement in cubic centimetres.",
+                "type": "attribute",
+                "unit": "cm^3"
+              },
+              "ECT": {
+                "datatype": "int16",
+                "deprecation": "v5.0 moved to EngineCoolant.Temperature",
+                "description": "Engine coolant temperature.",
+                "type": "sensor",
+                "unit": "celsius"
+              },
+              "EOP": {
+                "datatype": "uint16",
+                "description": "Engine oil pressure.",
+                "type": "sensor",
+                "unit": "kPa"
+              },
+              "EOT": {
+                "datatype": "int16",
+                "deprecation": "v5.0 moved to EngineOil.Temperature",
+                "description": "Engine oil temperature.",
+                "type": "sensor",
+                "unit": "celsius"
+              },
+              "EngineCode": {
+                "comment": "For hybrid vehicles the engine code may refer to the combination of combustion and electric engine.",
+                "datatype": "string",
+                "description": "Engine code designation, as specified by vehicle manufacturer.",
+                "type": "attribute"
+              },
+              "EngineCoolant": {
+                "children": {
+                  "Capacity": {
+                    "datatype": "float",
+                    "description": "Engine coolant capacity in liters.",
+                    "type": "attribute",
+                    "unit": "l"
+                  },
+                  "Level": {
+                    "allowed": [
+                      "CRITICALLY_LOW",
+                      "LOW",
+                      "NORMAL"
+                    ],
+                    "datatype": "string",
+                    "description": "Engine coolant level.",
+                    "type": "sensor"
+                  },
+                  "LifeRemaining": {
+                    "comment": "In addition to this a signal a vehicle can report remaining time to service (including e.g. coolant change) by Vehicle.Service.TimeToService.",
+                    "datatype": "int32",
+                    "description": "Remaining engine coolant life in seconds. Negative values can be used to indicate that lifetime has been exceeded.",
+                    "type": "sensor",
+                    "unit": "s"
+                  },
+                  "Temperature": {
+                    "datatype": "float",
+                    "description": "Engine coolant temperature.",
+                    "type": "sensor",
+                    "unit": "celsius"
+                  }
+                },
+                "description": "Signals related to the engine coolant",
+                "type": "branch"
+              },
+              "EngineCoolantCapacity": {
+                "datatype": "float",
+                "deprecation": "v5.0 moved to EngineCoolant.Capacity",
+                "description": "Engine coolant capacity in liters.",
+                "type": "attribute",
+                "unit": "l"
+              },
+              "EngineHours": {
+                "datatype": "float",
+                "description": "Accumulated time during engine lifetime with 'engine speed (rpm) > 0'.",
+                "type": "sensor",
+                "unit": "h"
+              },
+              "EngineOil": {
+                "children": {
+                  "Capacity": {
+                    "datatype": "float",
+                    "description": "Engine oil capacity in liters.",
+                    "type": "attribute",
+                    "unit": "l"
+                  },
+                  "Level": {
+                    "allowed": [
+                      "CRITICALLY_LOW",
+                      "LOW",
+                      "NORMAL",
+                      "HIGH",
+                      "CRITICALLY_HIGH"
+                    ],
+                    "datatype": "string",
+                    "description": "Engine oil level.",
+                    "type": "sensor"
+                  },
+                  "LifeRemaining": {
+                    "comment": "In addition to this a signal a vehicle can report remaining time to service (including e.g. oil change) by Vehicle.Service.TimeToService.",
+                    "datatype": "int32",
+                    "description": "Remaining engine oil life in seconds. Negative values can be used to indicate that lifetime has been exceeded.",
+                    "type": "sensor",
+                    "unit": "s"
+                  },
+                  "Temperature": {
+                    "datatype": "float",
+                    "description": "EOT, Engine oil temperature.",
+                    "type": "sensor",
+                    "unit": "celsius"
+                  }
+                },
+                "description": "Signals related to the engine oil",
+                "type": "branch"
+              },
+              "EngineOilCapacity": {
+                "datatype": "float",
+                "deprecation": "v5.0 moved to EngineOil.Capacity",
+                "description": "Engine oil capacity in liters.",
+                "type": "attribute",
+                "unit": "l"
+              },
+              "EngineOilLevel": {
+                "allowed": [
+                  "CRITICALLY_LOW",
+                  "LOW",
+                  "NORMAL",
+                  "HIGH",
+                  "CRITICALLY_HIGH"
+                ],
+                "datatype": "string",
+                "deprecation": "v5.0 moved to EngineOil.Level",
+                "description": "Engine oil level.",
+                "type": "sensor"
+              },
+              "IdleHours": {
+                "comment": "Vehicles may calculate accumulated idle time for an engine. It might be based on engine speed (rpm) below a certain limit or any other mechanism.",
+                "datatype": "float",
+                "description": "Accumulated idling time during engine lifetime. Definition of idling is not standardized.",
+                "type": "sensor",
+                "unit": "h"
+              },
+              "IsRunning": {
+                "datatype": "boolean",
+                "description": "Engine Running. True if engine is rotating (Speed > 0).",
+                "type": "sensor"
+              },
+              "MAF": {
+                "datatype": "uint16",
+                "description": "Grams of air drawn into engine per second.",
+                "type": "sensor",
+                "unit": "g/s"
+              },
+              "MAP": {
+                "datatype": "uint16",
+                "description": "Manifold absolute pressure possibly boosted using forced induction.",
+                "type": "sensor",
+                "unit": "kPa"
+              },
+              "MaxPower": {
+                "datatype": "uint16",
+                "default": 0,
+                "description": "Peak power, in kilowatts, that engine can generate.",
+                "type": "attribute",
+                "unit": "kW"
+              },
+              "MaxTorque": {
+                "datatype": "uint16",
+                "default": 0,
+                "description": "Peak torque, in newton meter, that the engine can generate.",
+                "type": "attribute",
+                "unit": "Nm"
+              },
+              "NumberOfCylinders": {
+                "datatype": "uint16",
+                "description": "Number of cylinders.",
+                "type": "attribute"
+              },
+              "NumberOfValvesPerCylinder": {
+                "datatype": "uint16",
+                "description": "Number of valves per cylinder.",
+                "type": "attribute"
+              },
+              "OilLifeRemaining": {
+                "comment": "In addition to this a signal a vehicle can report remaining time to service (including e.g. oil change) by Vehicle.Service.TimeToService.",
+                "datatype": "int32",
+                "deprecation": "v5.0 moved to EngineOil.LifeRemaining",
+                "description": "Remaining engine oil life in seconds. Negative values can be used to indicate that lifetime has been exceeded.",
+                "type": "sensor",
+                "unit": "s"
+              },
+              "Power": {
+                "datatype": "uint16",
+                "description": "Current engine power output. Shall be reported as 0 during engine breaking.",
+                "type": "sensor",
+                "unit": "kW"
+              },
+              "Speed": {
+                "datatype": "uint16",
+                "description": "Engine speed measured as rotations per minute.",
+                "type": "sensor",
+                "unit": "rpm"
+              },
+              "StrokeLength": {
+                "datatype": "float",
+                "description": "Stroke length in millimetres.",
+                "type": "attribute",
+                "unit": "mm"
+              },
+              "TPS": {
+                "datatype": "uint8",
+                "description": "Current throttle position.",
+                "max": 100,
+                "type": "sensor",
+                "unit": "percent"
+              },
+              "Torque": {
+                "comment": "During engine breaking the engine delivers a negative torque to the transmission. This negative torque shall be ignored, instead 0 shall be reported.",
+                "datatype": "uint16",
+                "description": "Current engine torque. Shall be reported as 0 during engine breaking.",
+                "type": "sensor",
+                "unit": "Nm"
+              }
+            },
+            "description": "Engine-specific data, stopping at the bell housing.",
+            "type": "branch"
+          },
+          "ElectricMotor": {
+            "children": {
+              "CoolantTemperature": {
+                "datatype": "int16",
+                "deprecation": "v5.0 moved to EngineCoolant.Temperature",
+                "description": "Motor coolant temperature (if applicable).",
+                "type": "sensor",
+                "unit": "celsius"
+              },
+              "EngineCode": {
+                "datatype": "string",
+                "description": "Engine code designation, as specified by vehicle manufacturer.",
+                "type": "attribute"
+              },
+              "EngineCoolant": {
+                "children": {
+                  "Capacity": {
+                    "datatype": "float",
+                    "description": "Engine coolant capacity in liters.",
+                    "type": "attribute",
+                    "unit": "l"
+                  },
+                  "Level": {
+                    "allowed": [
+                      "CRITICALLY_LOW",
+                      "LOW",
+                      "NORMAL"
+                    ],
+                    "datatype": "string",
+                    "description": "Engine coolant level.",
+                    "type": "sensor"
+                  },
+                  "LifeRemaining": {
+                    "comment": "In addition to this a signal a vehicle can report remaining time to service (including e.g. coolant change) by Vehicle.Service.TimeToService.",
+                    "datatype": "int32",
+                    "description": "Remaining engine coolant life in seconds. Negative values can be used to indicate that lifetime has been exceeded.",
+                    "type": "sensor",
+                    "unit": "s"
+                  },
+                  "Temperature": {
+                    "datatype": "float",
+                    "description": "Engine coolant temperature.",
+                    "type": "sensor",
+                    "unit": "celsius"
+                  }
+                },
+                "description": "Signals related to the engine coolant (if applicable).",
+                "type": "branch"
+              },
+              "MaxPower": {
+                "datatype": "uint16",
+                "default": 0,
+                "description": "Peak power, in kilowatts, that motor(s) can generate.",
+                "type": "attribute",
+                "unit": "kW"
+              },
+              "MaxRegenPower": {
+                "datatype": "uint16",
+                "default": 0,
+                "description": "Peak regen/brake power, in kilowatts, that motor(s) can generate.",
+                "type": "attribute",
+                "unit": "kW"
+              },
+              "MaxRegenTorque": {
+                "datatype": "uint16",
+                "default": 0,
+                "description": "Peak regen/brake torque, in newton meter, that the motor(s) can generate.",
+                "type": "attribute",
+                "unit": "Nm"
+              },
+              "MaxTorque": {
+                "datatype": "uint16",
+                "default": 0,
+                "description": "Peak power, in newton meter, that the motor(s) can generate.",
+                "type": "attribute",
+                "unit": "Nm"
+              },
+              "Power": {
+                "datatype": "int16",
+                "description": "Current motor power output. Negative values indicate regen mode.",
+                "type": "sensor",
+                "unit": "kW"
+              },
+              "Speed": {
+                "datatype": "int32",
+                "description": "Motor rotational speed measured as rotations per minute. Negative values indicate reverse driving mode.",
+                "type": "sensor",
+                "unit": "rpm"
+              },
+              "Temperature": {
+                "datatype": "int16",
+                "dbc2vss": {
+                  "interval_ms": 1000,
+                  "signal": "PTC_rightTempIGBT"
+                },
+                "description": "Motor temperature.",
+                "type": "sensor",
+                "unit": "celsius"
+              },
+              "TimeInUse": {
+                "comment": "Vehicles may define their READY state.",
+                "datatype": "float",
+                "description": "Accumulated time during engine lifetime when the vehicule state's is 'READY'.",
+                "type": "sensor",
+                "unit": "h"
+              },
+              "Torque": {
+                "datatype": "int16",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "DIR_torqueActual"
+                },
+                "description": "Current motor torque. Negative values indicate regen mode.",
+                "type": "sensor",
+                "unit": "Nm"
+              }
+            },
+            "description": "Electric Motor specific data.",
+            "type": "branch"
+          },
+          "FuelSystem": {
+            "children": {
+              "AbsoluteLevel": {
+                "datatype": "float",
+                "description": "Current available fuel in the fuel tank expressed in liters.",
+                "type": "sensor",
+                "unit": "l"
+              },
+              "AverageConsumption": {
+                "datatype": "float",
+                "description": "Average consumption in liters per 100 km.",
+                "min": 0,
+                "type": "sensor",
+                "unit": "l/100km"
+              },
+              "ConsumptionSinceStart": {
+                "comment": "A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new trip is started.",
+                "datatype": "float",
+                "description": "Fuel amount in liters consumed since start of current trip.",
+                "type": "sensor",
+                "unit": "l"
+              },
+              "HybridType": {
+                "allowed": [
+                  "UNKNOWN",
+                  "NOT_APPLICABLE",
+                  "STOP_START",
+                  "BELT_ISG",
+                  "CIMG",
+                  "PHEV"
+                ],
+                "datatype": "string",
+                "default": "UNKNOWN",
+                "description": "Defines the hybrid type of the vehicle.",
+                "type": "attribute"
+              },
+              "InstantConsumption": {
+                "datatype": "float",
+                "description": "Current consumption in liters per 100 km.",
+                "min": 0,
+                "type": "sensor",
+                "unit": "l/100km"
+              },
+              "IsEngineStopStartEnabled": {
+                "datatype": "boolean",
+                "description": "Indicates whether eco start stop is currently enabled.",
+                "type": "sensor"
+              },
+              "IsFuelLevelLow": {
+                "datatype": "boolean",
+                "description": "Indicates that the fuel level is low (e.g. <50km range).",
+                "type": "sensor"
+              },
+              "IsFuelPortFlapOpen": {
+                "datatype": "boolean",
+                "description": "Status of the fuel port flap(s). True if at least one is open.",
+                "type": "actuator"
+              },
+              "Range": {
+                "datatype": "uint32",
+                "description": "Remaining range in meters using only liquid fuel.",
+                "type": "sensor",
+                "unit": "m"
+              },
+              "RefuelPortPosition": {
+                "allowed": [
+                  "FRONT_LEFT",
+                  "FRONT_MIDDLE",
+                  "FRONT_RIGHT",
+                  "REAR_LEFT",
+                  "REAR_MIDDLE",
+                  "REAR_RIGHT",
+                  "LEFT_FRONT",
+                  "LEFT_MIDDLE",
+                  "LEFT_REAR",
+                  "RIGHT_FRONT",
+                  "RIGHT_MIDDLE",
+                  "RIGHT_REAR"
+                ],
+                "datatype": "string[]",
+                "description": "Position of refuel port(s). First part indicates side of vehicle, second part relative position on that side.",
+                "type": "attribute"
+              },
+              "RelativeLevel": {
+                "datatype": "uint8",
+                "description": "Level in fuel tank as percent of capacity. 0 = empty. 100 = full.",
+                "max": 100,
+                "min": 0,
+                "type": "sensor",
+                "unit": "percent"
+              },
+              "SupportedFuel": {
+                "allowed": [
+                  "E5_95",
+                  "E5_98",
+                  "E10_95",
+                  "E10_98",
+                  "E85",
+                  "B7",
+                  "B10",
+                  "B20",
+                  "B30",
+                  "B100",
+                  "XTL",
+                  "LPG",
+                  "CNG",
+                  "LNG",
+                  "H2",
+                  "OTHER"
+                ],
+                "comment": "RON 95 is sometimes referred to as Super, RON 98 as Super Plus.",
+                "datatype": "string[]",
+                "description": "Detailed information on fuels supported by the vehicle. Identifiers originating from DIN EN 16942:2021-08, appendix B, with additional suffix for octane (RON) where relevant.",
+                "type": "attribute"
+              },
+              "SupportedFuelTypes": {
+                "allowed": [
+                  "GASOLINE",
+                  "DIESEL",
+                  "E85",
+                  "LPG",
+                  "CNG",
+                  "LNG",
+                  "H2",
+                  "OTHER"
+                ],
+                "comment": "If a vehicle also has an electric drivetrain (e.g. hybrid) that will be obvious from the PowerTrain.Type signal.",
+                "datatype": "string[]",
+                "description": "High level information of fuel types supported",
+                "type": "attribute"
+              },
+              "TankCapacity": {
+                "datatype": "float",
+                "description": "Capacity of the fuel tank in liters.",
+                "type": "attribute",
+                "unit": "l"
+              },
+              "TimeRemaining": {
+                "datatype": "uint32",
+                "description": "Time remaining in seconds before the fuel tank is empty.",
+                "type": "sensor",
+                "unit": "s"
+              }
+            },
+            "description": "Fuel system data.",
+            "type": "branch"
+          },
+          "IsAutoPowerOptimize": {
+            "datatype": "boolean",
+            "description": "Auto Power Optimization Flag When set to 'true', the system enables automatic power optimization, dynamically adjusting the power optimization level based on runtime conditions or features managed by the OEM. When set to 'false', manual control of the power optimization level is allowed.",
+            "type": "actuator"
+          },
+          "PowerOptimizeLevel": {
+            "datatype": "uint8",
+            "description": "Power optimization level for this branch/subsystem. A higher number indicates more aggressive power optimization. Level 0 indicates that all functionality is enabled, no power optimization enabled. Level 10 indicates most aggressive power optimization mode, only essential functionality enabled.",
+            "max": 10,
+            "min": 0,
+            "type": "actuator"
+          },
+          "Range": {
+            "datatype": "uint32",
+            "description": "Remaining range in meters using all energy sources available in the vehicle.",
+            "type": "sensor",
+            "unit": "m"
+          },
+          "TimeRemaining": {
+            "datatype": "uint32",
+            "description": "Time remaining in seconds before all energy sources available in the vehicle are empty.",
+            "type": "sensor",
+            "unit": "s"
+          },
+          "TractionBattery": {
+            "children": {
+              "AccumulatedChargedEnergy": {
+                "datatype": "float",
+                "description": "The accumulated energy delivered to the battery during charging over lifetime of the battery.",
+                "type": "sensor",
+                "unit": "kWh"
+              },
+              "AccumulatedChargedThroughput": {
+                "datatype": "float",
+                "description": "The accumulated charge throughput delivered to the battery during charging over lifetime of the battery.",
+                "type": "sensor",
+                "unit": "Ah"
+              },
+              "AccumulatedConsumedEnergy": {
+                "datatype": "float",
+                "description": "The accumulated energy leaving HV battery for propulsion and auxiliary loads over lifetime of the battery.",
+                "type": "sensor",
+                "unit": "kWh"
+              },
+              "AccumulatedConsumedThroughput": {
+                "datatype": "float",
+                "description": "The accumulated charge throughput leaving HV battery for propulsion and auxiliary loads over lifetime of the battery.",
+                "type": "sensor",
+                "unit": "Ah"
+              },
+              "BatteryConditioning": {
+                "children": {
+                  "IsActive": {
+                    "comment": "This signal is typically true when mode is not INACTIVE and time is within defined start/end times.",
+                    "datatype": "boolean",
+                    "description": "Indicates if battery conditioning is active (i.e. actively monitors battery temperature). True = Active. False = Inactive.",
+                    "type": "sensor"
+                  },
+                  "IsOngoing": {
+                    "comment": "When battery conditioning is active, but temperature is already within acceptable range so that no cooling or heating is needed then IsOngoing shall report False.",
+                    "datatype": "boolean",
+                    "description": "Indicating if battery conditioning is currently ongoing. Battery conditioning is considered ongoing when the battery conditioning system is actively heating or cooling the battery, or requesting heating or cooling.",
+                    "type": "sensor"
+                  },
+                  "RequestedMode": {
+                    "allowed": [
+                      "INACTIVE",
+                      "FAST_CHARGING_PREPARATION",
+                      "DRIVING_PREPARATION"
+                    ],
+                    "comment": "The Mode and TargetTime can be used to calculate TargetTemperature and StartTime",
+                    "datatype": "string",
+                    "description": "Defines requested mode for battery conditioning. INACTIVE - Battery conditioning inactive. FAST_CHARGING_PREPARATION - Battery conditioning for fast charging. DRIVING_PREPARATION - Battery conditioning for driving.",
+                    "type": "actuator"
+                  },
+                  "StartTime": {
+                    "comment": "If the vehicle is asleep, this is the time the vehicle and the battery conditioning system must wake up and start monitoring the battery and if necessary start heating/cooling of the battery.",
+                    "datatype": "string",
+                    "description": "Start time for battery conditioning, formatted according to ISO 8601 with UTC time zone.",
+                    "type": "actuator",
+                    "unit": "iso8601"
+                  },
+                  "TargetTemperature": {
+                    "comment": "Target temperature possibly differs between different modes as well as other factors. Allowed deviation from target temperature is implementation dependent.",
+                    "datatype": "float",
+                    "description": "Target temperature for battery conditioning.",
+                    "type": "actuator",
+                    "unit": "celsius"
+                  },
+                  "TargetTime": {
+                    "comment": "For FAST_CHARGING mode this is typically the time when charging is supposed to start. For DRIVING mode this is typically the expected departure time. Battery conditioning will be deactivated when this time has passed.",
+                    "datatype": "string",
+                    "description": "Target time when conditioning shall be finished, formatted according to ISO 8601 with UTC time zone.",
+                    "type": "actuator",
+                    "unit": "iso8601"
+                  }
+                },
+                "description": "Properties related to preparing the vehicle battery for charging or driving.",
+                "type": "branch"
+              },
+              "CellVoltage": {
+                "children": {
+                  "CellVoltages": {
+                    "comment": "Cells are identified by relative position in array.",
+                    "datatype": "float[]",
+                    "description": "Array of cell voltages. Length or array shall correspond to number of cells in vehicle.",
+                    "type": "sensor"
+                  },
+                  "IdMax": {
+                    "comment": "Identifier is supposed to be relative index of the cell, starting with 0 the first cell.",
+                    "datatype": "uint16",
+                    "description": "Identifier of the battery cell with highest voltage.",
+                    "type": "sensor"
+                  },
+                  "IdMin": {
+                    "comment": "Identifier is supposed to be relative index of the cell, starting with 0 the first cell.",
+                    "datatype": "uint16",
+                    "description": "Identifier of the battery cell with lowest voltage.",
+                    "type": "sensor"
+                  },
+                  "Max": {
+                    "datatype": "float",
+                    "description": "Current voltage of the battery cell with highest voltage.",
+                    "type": "sensor",
+                    "unit": "V"
+                  },
+                  "Min": {
+                    "datatype": "float",
+                    "description": "Current voltage of the battery cell with lowest voltage.",
+                    "type": "sensor",
+                    "unit": "V"
+                  }
+                },
+                "description": "Voltage information for cells in the battery pack.",
+                "type": "branch"
+              },
+              "Charging": {
+                "children": {
+                  "AveragePower": {
+                    "datatype": "float",
+                    "description": "Average charging power of last or current charging event.",
+                    "type": "sensor",
+                    "unit": "kW"
+                  },
+                  "ChargeCurrent": {
+                    "children": {
+                      "DC": {
+                        "datatype": "float",
+                        "description": "Current DC charging current at inlet. Negative if returning energy to grid.",
+                        "type": "sensor",
+                        "unit": "A"
+                      },
+                      "Phase1": {
+                        "datatype": "float",
+                        "description": "Current AC charging current (rms) at inlet for Phase 1. Negative if returning energy to grid.",
+                        "type": "sensor",
+                        "unit": "A"
+                      },
+                      "Phase2": {
+                        "datatype": "float",
+                        "description": "Current AC charging current (rms) at inlet for Phase 2. Negative if returning energy to grid.",
+                        "type": "sensor",
+                        "unit": "A"
+                      },
+                      "Phase3": {
+                        "datatype": "float",
+                        "description": "Current AC charging current (rms) at inlet for Phase 3. Negative if returning energy to grid.",
+                        "type": "sensor",
+                        "unit": "A"
+                      }
+                    },
+                    "description": "Current charging current.",
+                    "type": "branch"
+                  },
+                  "ChargeLimit": {
+                    "datatype": "uint8",
+                    "default": 100,
+                    "description": "Target charge limit (state of charge) for battery.",
+                    "max": 100,
+                    "min": 0,
+                    "type": "actuator",
+                    "unit": "percent"
+                  },
+                  "ChargePlugType": {
+                    "allowed": [
+                      "IEC_TYPE_1_AC",
+                      "IEC_TYPE_2_AC",
+                      "IEC_TYPE_3_AC",
+                      "IEC_TYPE_4_DC",
+                      "IEC_TYPE_1_CCS_DC",
+                      "IEC_TYPE_2_CCS_DC",
+                      "TESLA_ROADSTER",
+                      "TESLA_HPWC",
+                      "TESLA_SUPERCHARGER",
+                      "GBT_AC",
+                      "GBT_DC",
+                      "OTHER"
+                    ],
+                    "comment": "A vehicle may have multiple charging inlets. The signal Charging.ChargePlugPosition can be used to indicate position of the charge plug. IEC_TYPE_1_AC refers to Type 1 as defined in IEC 62196-2. Also known as Yazaki or J1772 connector. IEC_TYPE_2_AC refers to Type 2 as defined in IEC 62196-2. Also known as Mennekes connector. IEC_TYPE_3_AC refers to Type 3 as defined in IEC 62196-2. Also known as Scame connector. IEC_TYPE_4_DC refers to AA configuration as defined in IEC 62196-3. Also known as Type 4 or CHAdeMO connector. IEC_TYPE_1_CCS_DC refers to EE Configuration as defined in IEC 62196-3. Also known as CCS1 or Combo1 connector. IEC_TYPE_2_CCS_DC refers to FF Configuration as defined in IEC 62196-3. Also known as CCS2 or Combo2 connector. TESLA_ROADSTER, TESLA_HPWC (High Power Wall Connector) and TESLA_SUPERCHARGER refer to non-standardized charging inlets/methods used by Tesla. GBT_AC refers to connector specified in GB/T 20234.2. GBT_DC refers to connector specified in GB/T 20234.3. Also specified as BB Configuration in IEC 62196-3. OTHER shall be used if the vehicle has a charging connector, but not one of the connectors listed above. For additional information see https://en.wikipedia.org/wiki/IEC_62196.",
+                    "datatype": "string[]",
+                    "deprecation": "V4.1 renamed to Charging.ChargePortType",
+                    "description": "Type of charge plugs (charging inlet) available on the vehicle. A charge plug type may occur multiple times in the list if there are multiple instances of that charge plug type. IEC types refer to IEC 62196,  GBT refers to  GB/T 20234.",
+                    "type": "attribute"
+                  },
+                  "ChargePortFlap": {
+                    "allowed": [
+                      "OPEN",
+                      "CLOSED"
+                    ],
+                    "datatype": "string",
+                    "deprecation": "V4.1 - Replaced with Charging.IsChargePortFlapOpen",
+                    "description": "Status of the charge port cover(s), can potentially be controlled manually. OPEN if at least one is open.",
+                    "type": "actuator"
+                  },
+                  "ChargePortPosition": {
+                    "allowed": [
+                      "FRONT_LEFT",
+                      "FRONT_MIDDLE",
+                      "FRONT_RIGHT",
+                      "REAR_LEFT",
+                      "REAR_MIDDLE",
+                      "REAR_RIGHT",
+                      "LEFT_FRONT",
+                      "LEFT_MIDDLE",
+                      "LEFT_REAR",
+                      "RIGHT_FRONT",
+                      "RIGHT_MIDDLE",
+                      "RIGHT_REAR"
+                    ],
+                    "comment": "Example - If this signal is [LEFT_FRONT, RIGHT_FRONT] and Charging.ChargePortType is [IEC_TYPE_2_AC, GBT_AC] that means that there is Mennekes port on the left side of the vehicle near the front, and a GB/T AC port on the right side, near the front.",
+                    "datatype": "string[]",
+                    "description": "Location of the charge port(s). First part indicates side of vehicle, second part relative position on that side. If supported, the list in this attribute shall have the same length as Charging.ChargePortType, and use same the relative order.",
+                    "type": "attribute"
+                  },
+                  "ChargePortType": {
+                    "allowed": [
+                      "IEC_TYPE_1_AC",
+                      "IEC_TYPE_2_AC",
+                      "IEC_TYPE_3_AC",
+                      "IEC_TYPE_4_DC",
+                      "IEC_TYPE_1_CCS_DC",
+                      "IEC_TYPE_2_CCS_DC",
+                      "TESLA_ROADSTER",
+                      "TESLA_HPWC",
+                      "TESLA_SUPERCHARGER",
+                      "GBT_AC",
+                      "GBT_DC",
+                      "OTHER"
+                    ],
+                    "comment": "A vehicle may have multiple charging ports. The signal Charging.ChargePortPosition can be used to indicate position of the charge port. IEC_TYPE_1_AC refers to Type 1 as defined in IEC 62196-2. Also known as Yazaki or J1772 connector. IEC_TYPE_2_AC refers to Type 2 as defined in IEC 62196-2. Also known as Mennekes connector. IEC_TYPE_3_AC refers to Type 3 as defined in IEC 62196-2. Also known as Scame connector. IEC_TYPE_4_DC refers to AA configuration as defined in IEC 62196-3. Also known as Type 4 or CHAdeMO connector. IEC_TYPE_1_CCS_DC refers to EE Configuration as defined in IEC 62196-3. Also known as CCS1 or Combo1 connector. IEC_TYPE_2_CCS_DC refers to FF Configuration as defined in IEC 62196-3. Also known as CCS2 or Combo2 connector. TESLA_ROADSTER, TESLA_HPWC (High Power Wall Connector) and TESLA_SUPERCHARGER refer to non-standardized charging ports/methods used by Tesla. GBT_AC refers to connector specified in GB/T 20234.2. GBT_DC refers to connector specified in GB/T 20234.3. Also specified as BB Configuration in IEC 62196-3. OTHER shall be used for charging ports not included in the list above. For additional information see https://en.wikipedia.org/wiki/IEC_62196.",
+                    "datatype": "string[]",
+                    "description": "Type of charge ports (charging inlet) available on the vehicle. A charge port type may occur multiple times in the list if there are multiple instances of that charge port type. IEC types refer to IEC 62196,  GBT refers to  GB/T 20234.",
+                    "type": "attribute"
+                  },
+                  "ChargeRate": {
+                    "datatype": "float",
+                    "description": "Current charging rate, as in kilometers of range added per hour.",
+                    "type": "sensor",
+                    "unit": "km/h"
+                  },
+                  "ChargeVoltage": {
+                    "children": {
+                      "DC": {
+                        "datatype": "float",
+                        "description": "Current DC charging voltage at charging inlet.",
+                        "type": "sensor",
+                        "unit": "V"
+                      },
+                      "Phase1": {
+                        "datatype": "float",
+                        "description": "Current AC charging voltage (rms) at inlet for Phase 1.",
+                        "type": "sensor",
+                        "unit": "V"
+                      },
+                      "Phase2": {
+                        "datatype": "float",
+                        "description": "Current AC charging voltage (rms) at inlet for Phase 2.",
+                        "type": "sensor",
+                        "unit": "V"
+                      },
+                      "Phase3": {
+                        "datatype": "float",
+                        "description": "Current AC charging voltage (rms) at inlet for Phase 3.",
+                        "type": "sensor",
+                        "unit": "V"
+                      }
+                    },
+                    "description": "Current charging voltage, as measured at the charging inlet.",
+                    "type": "branch"
+                  },
+                  "EvseId": {
+                    "comment": "Length of id between 7 and 37 characters. ZZ00000 to be used if SECC cannot provide id",
+                    "datatype": "string",
+                    "description": "EVSE charging point ID (without separators) of last or current charging event according to ISO 15118-2 Annex H.",
+                    "type": "sensor"
+                  },
+                  "IsChargePortFlapOpen": {
+                    "datatype": "boolean",
+                    "description": "Status of the charge port flap(s), can potentially be controlled manually. True if at least one is open.",
+                    "type": "actuator"
+                  },
+                  "IsCharging": {
+                    "datatype": "boolean",
+                    "dbc2vss": {
+                      "interval_ms": 1000,
+                      "signal": "CP_hvChargeStatus",
+                      "transform": {
+                        "mapping": [
+                          {
+                            "from": "CP_CHARGE_CONNECTED",
+                            "to": false
+                          },
+                          {
+                            "from": "CP_CHARGE_ENABLED",
+                            "to": true
+                          },
+                          {
+                            "from": "CP_CHARGE_FAULTED",
+                            "to": false
+                          },
+                          {
+                            "from": "CP_CHARGE_INACTIVE",
+                            "to": false
+                          },
+                          {
+                            "from": "CP_CHARGE_STANDBY",
+                            "to": false
+                          },
+                          {
+                            "from": "CP_EVSE_TEST_PASSED",
+                            "to": true
+                          },
+                          {
+                            "from": "CP_EXT_EVSE_TEST_ACTIVE",
+                            "to": true
+                          }
+                        ]
+                      }
+                    },
+                    "description": "True if charging is ongoing. Charging is considered to be ongoing if energy is flowing from charger to vehicle.",
+                    "type": "sensor"
+                  },
+                  "IsChargingCableConnected": {
+                    "datatype": "boolean",
+                    "description": "Indicates if a charging cable is physically connected to the vehicle or not.",
+                    "type": "sensor"
+                  },
+                  "IsChargingCableLocked": {
+                    "comment": "Locking of charging cable can be used to prevent unintentional removing during charging.",
+                    "datatype": "boolean",
+                    "description": "Is charging cable locked to prevent removal.",
+                    "type": "actuator"
+                  },
+                  "IsDischarging": {
+                    "datatype": "boolean",
+                    "description": "True if discharging (vehicle to grid) is ongoing. Discharging is considered to be ongoing if energy is flowing from vehicle to charger/grid.",
+                    "type": "sensor"
+                  },
+                  "Location": {
+                    "children": {
+                      "Altitude": {
+                        "datatype": "double",
+                        "description": "Altitude relative to WGS 84 reference ellipsoid of last or current charging event.",
+                        "type": "sensor",
+                        "unit": "m"
+                      },
+                      "Latitude": {
+                        "datatype": "double",
+                        "description": "Latitude of last or current charging event in WGS 84 geodetic coordinates.",
+                        "max": 90,
+                        "min": -90,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      },
+                      "Longitude": {
+                        "datatype": "double",
+                        "description": "Longitude of last or current charging event in WGS 84 geodetic coordinates.",
+                        "max": 180,
+                        "min": -180,
+                        "type": "sensor",
+                        "unit": "degrees"
+                      }
+                    },
+                    "comment": "This may depending on implementation represent the location of (the charge port of) the vehicle during charging, or the actual location of the charger/load connected to the vehicle.",
+                    "description": "Location of last or current charging event.",
+                    "type": "branch"
+                  },
+                  "MaxPower": {
+                    "datatype": "float",
+                    "description": "Maximum charging power of last or current charging event.",
+                    "type": "sensor",
+                    "unit": "kW"
+                  },
+                  "MaximumChargingCurrent": {
+                    "children": {
+                      "DC": {
+                        "datatype": "float",
+                        "description": "Maximum DC charging current at inlet that can be accepted by the system.",
+                        "type": "sensor",
+                        "unit": "A"
+                      },
+                      "Phase1": {
+                        "datatype": "float",
+                        "description": "Maximum AC charging current (rms) at inlet for Phase 1 that can be accepted by the system.",
+                        "type": "sensor",
+                        "unit": "A"
+                      },
+                      "Phase2": {
+                        "datatype": "float",
+                        "description": "Maximum AC charging current (rms) at inlet for Phase 2 that can be accepted by the system.",
+                        "type": "sensor",
+                        "unit": "A"
+                      },
+                      "Phase3": {
+                        "datatype": "float",
+                        "description": "Maximum AC charging current (rms) at inlet for Phase 3 that can be accepted by the system.",
+                        "type": "sensor",
+                        "unit": "A"
+                      }
+                    },
+                    "description": "Maximum charging current that can be accepted by the system, as measured at the charging inlet.",
+                    "type": "branch"
+                  },
+                  "Mode": {
+                    "allowed": [
+                      "DEACTIVATED",
+                      "AUTOMATIC",
+                      "TRIGGERED",
+                      "TIMER",
+                      "PROFILE",
+                      "EXTERNAL_ENTITY",
+                      "MANUAL",
+                      "GRID"
+                    ],
+                    "comment": "EXTERNAL_ENTITY is the only mode where discharge may occur. The mechanism to provide a profile to the vehicle is currently not covered by VSS.",
+                    "datatype": "string",
+                    "deprecation": "V4.1 - MANUAL and GRID are deprecated, please use AUTOMATIC/TRIGGERED or EXTERNAL_ENITY instead.",
+                    "description": "Describes how the charging process is controlled. DEACTIVATED means that charging and discharging is deactivated, nothing will happen if charger is connected. AUTOMATIC means charging will be initiated as soon as charger is connected. TRIGGERED means charging will be initiated when triggered by user. TIMER means charging is timer-based. PROFILE means charging is controlled by profile downloaded to vehicle. EXTERNAL_ENTITY means charging/discharging is controlled by the external entity connected to the vehicle. This includes GRID-controlled charging (e.g. ISO 15118), but also other cases where vehicle is connected to an arbitrary load that is powered by the vehicle. MANUAL means manually initiated (plug-in event, companion app, etc). GRID means grid-controlled (e.g. ISO 15118).",
+                    "type": "actuator"
+                  },
+                  "PowerLoss": {
+                    "datatype": "float",
+                    "description": "Electrical energy lost by power dissipation to heat inside the AC/DC converter.",
+                    "type": "sensor",
+                    "unit": "W"
+                  },
+                  "StartStopCharging": {
+                    "allowed": [
+                      "START",
+                      "STOP"
+                    ],
+                    "datatype": "string",
+                    "description": "Start or stop the charging process.",
+                    "type": "actuator"
+                  },
+                  "Temperature": {
+                    "datatype": "float",
+                    "description": "Current temperature of AC/DC converter converting grid voltage to battery voltage.",
+                    "type": "sensor",
+                    "unit": "celsius"
+                  },
+                  "TimeToComplete": {
+                    "comment": "Shall consider time set by Charging.Timer.Time. E.g. if charging shall start in 3 hours and 2 hours of charging is needed, then Charging.TimeToComplete shall report 5 hours.",
+                    "datatype": "uint32",
+                    "description": "The time needed for the current charging process to reach Charging.ChargeLimit. 0 if charging is complete or no charging process is active or planned.",
+                    "type": "sensor",
+                    "unit": "s"
+                  },
+                  "Timer": {
+                    "children": {
+                      "Mode": {
+                        "allowed": [
+                          "INACTIVE",
+                          "START_TIME",
+                          "END_TIME"
+                        ],
+                        "datatype": "string",
+                        "description": "Defines timer mode for charging: INACTIVE - no timer set, charging may start as soon as battery is connected to a charger. START_TIME - charging shall start at Charging.Timer.Time. END_TIME - charging shall be finished (reach Charging.ChargeLimit) at Charging.Timer.Time. When charging is completed the vehicle shall change mode to 'inactive' or set a new Charging.Timer.Time. Charging shall start immediately if mode is 'starttime' or 'endtime' and Charging.Timer.Time is a time in the past.",
+                        "type": "actuator"
+                      },
+                      "Time": {
+                        "datatype": "string",
+                        "description": "Time for next charging-related action, formatted according to ISO 8601 with UTC time zone. Value has no significance if Charging.Timer.Mode is 'inactive'.",
+                        "type": "actuator",
+                        "unit": "iso8601"
+                      }
+                    },
+                    "description": "Properties related to timing of battery charging sessions.",
+                    "type": "branch"
+                  }
+                },
+                "description": "Properties related to battery charging.",
+                "type": "branch"
+              },
+              "CurrentCurrent": {
+                "datatype": "float",
+                "description": "Current current flowing in/out of battery. Positive = Current flowing in to battery, e.g. during charging. Negative = Current flowing out of battery, e.g. during driving.",
+                "type": "sensor",
+                "unit": "A"
+              },
+              "CurrentPower": {
+                "datatype": "float",
+                "description": "Current electrical energy flowing in/out of battery. Positive = Energy flowing in to battery, e.g. during charging. Negative = Energy flowing out of battery, e.g. during driving.",
+                "type": "sensor",
+                "unit": "W"
+              },
+              "CurrentVoltage": {
+                "datatype": "float",
+                "description": "Current Voltage of the battery.",
+                "type": "sensor",
+                "unit": "V"
+              },
+              "DCDC": {
+                "children": {
+                  "PowerLoss": {
+                    "datatype": "float",
+                    "description": "Electrical energy lost by power dissipation to heat inside DC/DC converter.",
+                    "type": "sensor",
+                    "unit": "W"
+                  },
+                  "Temperature": {
+                    "datatype": "float",
+                    "description": "Current temperature of DC/DC converter converting battery high voltage to vehicle low voltage (typically 12 Volts).",
+                    "type": "sensor",
+                    "unit": "celsius"
+                  }
+                },
+                "description": "Properties related to DC/DC converter converting high voltage (from high voltage battery) to vehicle low voltage (supply voltage, typically 12 Volts).",
+                "type": "branch"
+              },
+              "ErrorCodes": {
+                "comment": "Error code format is not defined, it may be DTCs according to OBD II (SAE-J2012DA_201812) standard ([P|C|B|U]XXXXX ) or any other format.",
+                "datatype": "string[]",
+                "description": "Current error codes related to the battery, if any.",
+                "type": "sensor"
+              },
+              "GrossCapacity": {
+                "datatype": "uint16",
+                "description": "Gross capacity of the battery.",
+                "type": "attribute",
+                "unit": "kWh"
+              },
+              "Id": {
+                "comment": "This could be serial number, part number plus serial number, UUID, or any other identifier that the OEM want to use to uniquely identify the battery individual.",
+                "datatype": "string",
+                "description": "Battery Identification Number as assigned by OEM.",
+                "type": "attribute"
+              },
+              "IsGroundConnected": {
+                "comment": "It might be possible to disconnect the traction battery used by an electric powertrain. This is achieved by connectors, typically one for plus and one for minus.",
+                "datatype": "boolean",
+                "description": "Indicating if the ground (negative terminator) of the traction battery is connected to the powertrain.",
+                "type": "sensor"
+              },
+              "IsPowerConnected": {
+                "comment": "It might be possible to disconnect the traction battery used by an electric powertrain. This is achieved by connectors, typically one for plus and one for minus.",
+                "datatype": "boolean",
+                "description": "Indicating if the power (positive terminator) of the traction battery is connected to the powertrain.",
+                "type": "sensor"
+              },
+              "MaxVoltage": {
+                "datatype": "uint16",
+                "description": "Max allowed voltage of the battery, e.g. during charging.",
+                "type": "attribute",
+                "unit": "V"
+              },
+              "NetCapacity": {
+                "datatype": "uint16",
+                "description": "Total net capacity of the battery considering aging.",
+                "type": "sensor",
+                "unit": "kWh"
+              },
+              "NominalVoltage": {
+                "comment": "Nominal voltage typically refers to voltage of fully charged battery when delivering rated capacity.",
+                "datatype": "uint16",
+                "description": "Nominal Voltage of the battery.",
+                "type": "attribute",
+                "unit": "V"
+              },
+              "PowerLoss": {
+                "datatype": "float",
+                "description": "Electrical energy lost by power dissipation to heat inside the battery.",
+                "type": "sensor",
+                "unit": "W"
+              },
+              "ProductionDate": {
+                "datatype": "string",
+                "description": "Production date of battery in ISO8601 format, e.g. YYYY-MM-DD.",
+                "type": "attribute",
+                "unit": "iso8601"
+              },
+              "Range": {
+                "datatype": "uint32",
+                "description": "Remaining range in meters using only battery.",
+                "type": "sensor",
+                "unit": "m"
+              },
+              "StateOfCharge": {
+                "children": {
+                  "Current": {
+                    "datatype": "float",
+                    "description": "Physical state of charge of the high voltage battery, relative to net capacity. This is not necessarily the state of charge being displayed to the customer.",
+                    "max": 100.0,
+                    "min": 0,
+                    "type": "sensor",
+                    "unit": "percent"
+                  },
+                  "CurrentEnergy": {
+                    "comment": "Current energy could be calculated as .StateOfCharge.Current * .NetCapacity.",
+                    "datatype": "float",
+                    "description": "Physical state of charge of high voltage battery expressed in kWh.",
+                    "type": "sensor",
+                    "unit": "kWh"
+                  },
+                  "Displayed": {
+                    "datatype": "float",
+                    "description": "State of charge displayed to the customer.",
+                    "max": 100.0,
+                    "min": 0,
+                    "type": "sensor",
+                    "unit": "percent"
+                  }
+                },
+                "description": "Information on the state of charge of the vehicle's high voltage battery.",
+                "type": "branch"
+              },
+              "StateOfHealth": {
+                "comment": "Exact formula is implementation dependent. Could be e.g. current capacity at 20 degrees Celsius divided with original capacity at the same temperature.",
+                "datatype": "float",
+                "description": "Calculated battery state of health at standard conditions.",
+                "max": 100,
+                "min": 0,
+                "type": "sensor",
+                "unit": "percent"
+              },
+              "Temperature": {
+                "children": {
+                  "Average": {
+                    "datatype": "float",
+                    "description": "Current average temperature of the battery cells.",
+                    "type": "sensor",
+                    "unit": "celsius"
+                  },
+                  "CellTemperature": {
+                    "comment": "Cells are identified by relative position in array.",
+                    "datatype": "float[]",
+                    "description": "Array of cell temperatures. Length or array shall correspond to number of cells in vehicle.",
+                    "type": "sensor"
+                  },
+                  "Max": {
+                    "datatype": "float",
+                    "description": "Current maximum temperature of the battery cells, i.e. temperature of the hottest cell.",
+                    "type": "sensor",
+                    "unit": "celsius"
+                  },
+                  "Min": {
+                    "datatype": "float",
+                    "description": "Current minimum temperature of the battery cells, i.e. temperature of the coldest cell.",
+                    "type": "sensor",
+                    "unit": "celsius"
+                  }
+                },
+                "description": "Temperature Information for the battery pack.",
+                "type": "branch"
+              },
+              "TimeRemaining": {
+                "datatype": "uint32",
+                "description": "Time remaining in seconds before the battery is empty.",
+                "type": "sensor",
+                "unit": "s"
+              }
+            },
+            "description": "Battery Management data.",
+            "type": "branch"
+          },
+          "Transmission": {
+            "children": {
+              "ClutchEngagement": {
+                "datatype": "float",
+                "description": "Clutch engagement. 0% = Clutch fully disengaged. 100% = Clutch fully engaged.",
+                "max": 100,
+                "min": 0,
+                "type": "actuator",
+                "unit": "percent"
+              },
+              "ClutchWear": {
+                "datatype": "uint8",
+                "description": "Clutch wear as a percent. 0 = no wear. 100 = worn.",
+                "max": 100,
+                "type": "sensor",
+                "unit": "percent"
+              },
+              "CurrentGear": {
+                "datatype": "int8",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "DI_gear",
+                  "transform": {
+                    "mapping": [
+                      {
+                        "from": "DI_GEAR_D",
+                        "to": 1
+                      },
+                      {
+                        "from": "DI_GEAR_P",
+                        "to": 0
+                      },
+                      {
+                        "from": "DI_GEAR_INVALID",
+                        "to": 0
+                      },
+                      {
+                        "from": "DI_GEAR_R",
+                        "to": -1
+                      }
+                    ]
+                  }
+                },
+                "description": "The current gear. 0=Neutral, 1/2/..=Forward, -1/-2/..=Reverse.",
+                "type": "sensor"
+              },
+              "DiffLockFrontEngagement": {
+                "datatype": "float",
+                "description": "Front Diff Lock engagement. 0% = Diff lock fully disengaged. 100% = Diff lock fully engaged.",
+                "max": 100,
+                "min": 0,
+                "type": "actuator",
+                "unit": "percent"
+              },
+              "DiffLockRearEngagement": {
+                "datatype": "float",
+                "description": "Rear Diff Lock engagement. 0% = Diff lock fully disengaged. 100% = Diff lock fully engaged.",
+                "max": 100,
+                "min": 0,
+                "type": "actuator",
+                "unit": "percent"
+              },
+              "DriveType": {
+                "allowed": [
+                  "UNKNOWN",
+                  "FORWARD_WHEEL_DRIVE",
+                  "REAR_WHEEL_DRIVE",
+                  "ALL_WHEEL_DRIVE"
+                ],
+                "datatype": "string",
+                "default": "UNKNOWN",
+                "description": "Drive type.",
+                "type": "attribute"
+              },
+              "GearChangeMode": {
+                "allowed": [
+                  "MANUAL",
+                  "AUTOMATIC"
+                ],
+                "datatype": "string",
+                "description": "Is the gearbox in automatic or manual (paddle) mode.",
+                "type": "actuator"
+              },
+              "GearCount": {
+                "datatype": "int8",
+                "default": 0,
+                "description": "Number of forward gears in the transmission. -1 = CVT.",
+                "type": "attribute"
+              },
+              "IsElectricalPowertrainEngaged": {
+                "comment": "In some hybrid solutions it is possible to disconnect/disengage the electrical powertrain mechanically to avoid induced voltage reaching a too high level when driving at high speed.",
+                "datatype": "boolean",
+                "description": "Is electrical powertrain mechanically connected/engaged to the drivetrain or not. False = Disconnected/Disengaged. True = Connected/Engaged.",
+                "type": "actuator"
+              },
+              "IsLowRangeEngaged": {
+                "comment": "The possibility to switch between low and high gear range is typically only available in heavy vehicles and off-road vehicles.",
+                "datatype": "boolean",
+                "description": "Is gearbox in low range mode or not. False = Normal/High range engaged. True = Low range engaged.",
+                "type": "actuator"
+              },
+              "IsParkLockEngaged": {
+                "datatype": "boolean",
+                "dbc2vss": {
+                  "interval_ms": 100,
+                  "signal": "DI_gear",
+                  "transform": {
+                    "mapping": [
+                      {
+                        "from": "DI_GEAR_D",
+                        "to": false
+                      },
+                      {
+                        "from": "DI_GEAR_P",
+                        "to": true
+                      },
+                      {
+                        "from": "DI_GEAR_INVALID",
+                        "to": false
+                      },
+                      {
+                        "from": "DI_GEAR_R",
+                        "to": false
+                      }
+                    ]
+                  }
+                },
+                "description": "Is the transmission park lock engaged or not. False = Disengaged. True = Engaged.",
+                "type": "sensor"
+              },
+              "PerformanceMode": {
+                "allowed": [
+                  "NORMAL",
+                  "SPORT",
+                  "ECONOMY",
+                  "SNOW",
+                  "RAIN"
+                ],
+                "datatype": "string",
+                "description": "Current gearbox performance mode.",
+                "type": "actuator"
+              },
+              "SelectedGear": {
+                "datatype": "int8",
+                "description": "The selected gear. 0=Neutral, 1/2/..=Forward, -1/-2/..=Reverse, 126=Park, 127=Drive.",
+                "type": "actuator"
+              },
+              "Temperature": {
+                "datatype": "int16",
+                "description": "The current gearbox temperature.",
+                "type": "sensor",
+                "unit": "celsius"
+              },
+              "TorqueDistribution": {
+                "datatype": "float",
+                "description": "Torque distribution between front and rear axle in percent. -100% = Full torque to front axle, 0% = 50:50 Front/Rear, 100% = Full torque to rear axle.",
+                "max": 100,
+                "min": -100,
+                "type": "actuator",
+                "unit": "percent"
+              },
+              "TravelledDistance": {
+                "datatype": "float",
+                "description": "Odometer reading, total distance travelled during the lifetime of the transmission.",
+                "type": "sensor",
+                "unit": "km"
+              },
+              "Type": {
+                "allowed": [
+                  "UNKNOWN",
+                  "SEQUENTIAL",
+                  "H",
+                  "AUTOMATIC",
+                  "DSG",
+                  "CVT"
+                ],
+                "datatype": "string",
+                "default": "UNKNOWN",
+                "description": "Transmission type.",
+                "type": "attribute"
+              }
+            },
+            "description": "Transmission-specific data, stopping at the drive shafts.",
+            "type": "branch"
+          },
+          "Type": {
+            "allowed": [
+              "COMBUSTION",
+              "HYBRID",
+              "ELECTRIC"
+            ],
+            "comment": "For vehicles with a combustion engine (including hybrids) more detailed information on fuels supported can be found in FuelSystem.SupportedFuelTypes and FuelSystem.SupportedFuels.",
+            "datatype": "string",
+            "description": "Defines the powertrain type of the vehicle.",
+            "type": "attribute"
+          }
+        },
+        "description": "Powertrain data for battery management, etc.",
+        "type": "branch"
+      },
+      "RoofLoad": {
+        "datatype": "int16",
+        "description": "The permitted total weight of cargo and installations (e.g. a roof rack) on top of the vehicle.",
+        "type": "attribute",
+        "unit": "kg"
+      },
+      "Service": {
+        "children": {
+          "DistanceToService": {
+            "datatype": "float",
+            "description": "Remaining distance to service (of any kind). Negative values indicate service overdue.",
+            "type": "sensor",
+            "unit": "km"
+          },
+          "IsServiceDue": {
+            "datatype": "boolean",
+            "description": "Indicates if vehicle needs service (of any kind). True = Service needed now or in the near future. False = No known need for service.",
+            "type": "sensor"
+          },
+          "TimeToService": {
+            "datatype": "int32",
+            "description": "Remaining time to service (of any kind). Negative values indicate service overdue.",
+            "type": "sensor",
+            "unit": "s"
+          }
+        },
+        "description": "Service data.",
+        "type": "branch"
+      },
+      "Speed": {
+        "datatype": "float",
+        "dbc2vss": {
+          "interval_ms": 100,
+          "signal": "DI_uiSpeed"
+        },
+        "description": "Vehicle speed.",
+        "type": "sensor",
+        "unit": "km/h"
+      },
+      "StartTime": {
+        "comment": "This signal is supposed to be set whenever a new trip starts. A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The default value indicates that the vehicle never has been started, or that latest start time is unknown.",
+        "datatype": "string",
+        "default": "0000-01-01T00:00Z",
+        "description": "Start time of current or latest trip, formatted according to ISO 8601 with UTC time zone.",
+        "type": "attribute",
+        "unit": "iso8601"
+      },
+      "Trailer": {
+        "children": {
+          "IsConnected": {
+            "datatype": "boolean",
+            "dbc2vss": {
+              "interval_ms": 3000,
+              "signal": "VCLEFT_trailerDetected",
+              "transform": {
+                "mapping": [
+                  {
+                    "from": "TRAILER_LIGHT_DETECTION_SNA",
+                    "to": false
+                  },
+                  {
+                    "from": "TRAILER_LIGHT_DETECTION_DETECTED",
+                    "to": true
+                  },
+                  {
+                    "from": "TRAILER_LIGHT_DETECTION_FAULT",
+                    "to": false
+                  },
+                  {
+                    "from": "TRAILER_LIGHT_DETECTION_NOT_DETECTED",
+                    "to": false
+                  }
+                ]
+              }
+            },
+            "description": "Signal indicating if trailer is connected or not.",
+            "type": "sensor"
+          }
+        },
+        "description": "Trailer signals.",
+        "type": "branch"
+      },
+      "TraveledDistance": {
+        "datatype": "float",
+        "description": "Odometer reading, total distance traveled during the lifetime of the vehicle.",
+        "type": "sensor",
+        "unit": "km"
+      },
+      "TraveledDistanceSinceStart": {
+        "comment": "A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new trip is started.",
+        "datatype": "float",
+        "description": "Distance traveled since start of current trip.",
+        "type": "sensor",
+        "unit": "km"
+      },
+      "TripDuration": {
+        "comment": "This signal is not assumed to be continuously updated, but instead set to 0 when a trip starts and set to the actual duration of the trip when a trip ends. A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled.",
+        "datatype": "float",
+        "description": "Duration of latest trip.",
+        "type": "sensor",
+        "unit": "s"
+      },
+      "TripMeterReading": {
+        "comment": "The trip meter is an odometer that can be manually reset by the driver",
+        "datatype": "float",
+        "description": "Trip meter reading.",
+        "type": "actuator",
+        "unit": "km"
+      },
+      "TurningDiameter": {
+        "datatype": "uint16",
+        "description": "Minimum turning diameter, Wall-to-Wall, as defined by SAE J1100-2009 D102.",
+        "type": "attribute",
+        "unit": "mm"
+      },
+      "VehicleIdentification": {
+        "children": {
+          "AcrissCode": {
+            "datatype": "string",
+            "description": "The ACRISS Car Classification Code is a code used by many car rental companies.",
+            "type": "attribute"
+          },
+          "BodyType": {
+            "datatype": "string",
+            "description": "Indicates the design and body style of the vehicle (e.g. station wagon, hatchback, etc.).",
+            "type": "attribute"
+          },
+          "Brand": {
+            "datatype": "string",
+            "description": "Vehicle brand or manufacturer.",
+            "type": "attribute"
+          },
+          "DateVehicleFirstRegistered": {
+            "datatype": "string",
+            "description": "The date in ISO 8601 format of the first registration of the vehicle with the respective public authorities.",
+            "type": "attribute",
+            "unit": "iso8601"
+          },
+          "KnownVehicleDamages": {
+            "datatype": "string",
+            "description": "A textual description of known damages, both repaired and unrepaired.",
+            "type": "attribute"
+          },
+          "LicensePlate": {
+            "comment": "Depending on the context, this attribute might not be up to date or might be misconfigured, and therefore should be considered untrustworthy in the absence of another method of verification.",
+            "datatype": "string",
+            "description": "The license plate of the vehicle.",
+            "type": "attribute"
+          },
+          "MeetsEmissionStandard": {
+            "datatype": "string",
+            "description": "Indicates that the vehicle meets the respective emission standard.",
+            "type": "attribute"
+          },
+          "Model": {
+            "datatype": "string",
+            "description": "Vehicle model.",
+            "type": "attribute"
+          },
+          "OptionalExtras": {
+            "comment": "Allowed values are not standardized, each OEM can specify detail descriptions of array elements.",
+            "datatype": "string[]",
+            "description": "Optional extras refers to all car equipment options that are not installed as standard by the manufacturer.",
+            "type": "attribute"
+          },
+          "ProductionDate": {
+            "datatype": "string",
+            "description": "The date in ISO 8601 format of production of the item, e.g. vehicle.",
+            "type": "attribute",
+            "unit": "iso8601"
+          },
+          "PurchaseDate": {
+            "datatype": "string",
+            "description": "The date in ISO 8601 format of the item e.g. vehicle was purchased by the current owner.",
+            "type": "attribute",
+            "unit": "iso8601"
+          },
+          "VIN": {
+            "datatype": "string",
+            "description": "17-character Vehicle Identification Number (VIN) as defined by ISO 3779.",
+            "type": "attribute"
+          },
+          "VehicleConfiguration": {
+            "datatype": "string",
+            "description": "A short text indicating the configuration of the vehicle, e.g. '5dr hatchback ST 2.5 MT 225 hp' or 'limited edition'.",
+            "type": "attribute"
+          },
+          "VehicleExteriorColor": {
+            "datatype": "string",
+            "description": "The main color of the exterior within the basic color palette (eg. red, blue, black, white, ...).",
+            "type": "attribute"
+          },
+          "VehicleInteriorColor": {
+            "datatype": "string",
+            "description": "The color or color combination of the interior of the vehicle.",
+            "type": "attribute"
+          },
+          "VehicleInteriorType": {
+            "datatype": "string",
+            "description": "The type or material of the interior of the vehicle (e.g. synthetic fabric, leather, wood, etc.).",
+            "type": "attribute"
+          },
+          "VehicleModelDate": {
+            "datatype": "string",
+            "description": "The release date in ISO 8601 format of a vehicle model (often used to differentiate versions of the same make and model).",
+            "type": "attribute",
+            "unit": "iso8601"
+          },
+          "VehicleSeatingCapacity": {
+            "datatype": "uint16",
+            "description": "The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law.",
+            "type": "attribute"
+          },
+          "VehicleSpecialUsage": {
+            "datatype": "string",
+            "description": "Indicates whether the vehicle has been used for special purposes, like commercial rental, driving school.",
+            "type": "attribute"
+          },
+          "WMI": {
+            "datatype": "string",
+            "description": "3-character World Manufacturer Identification (WMI) as defined by ISO 3780.",
+            "type": "attribute"
+          },
+          "Year": {
+            "datatype": "uint16",
+            "description": "Model year of the vehicle.",
+            "type": "attribute"
+          }
+        },
+        "description": "Attributes that identify a vehicle.",
+        "type": "branch"
+      },
+      "VersionVSS": {
+        "children": {
+          "Label": {
+            "comment": "COVESA VSS project typically use dev for latest master, and empty string for released versions.",
+            "datatype": "string",
+            "description": "Label to further describe the version.",
+            "type": "attribute"
+          },
+          "Major": {
+            "datatype": "uint32",
+            "default": 4,
+            "description": "Supported Version of VSS - Major version.",
+            "type": "attribute"
+          },
+          "Minor": {
+            "datatype": "uint32",
+            "default": 2,
+            "description": "Supported Version of VSS - Minor version.",
+            "type": "attribute"
+          },
+          "Patch": {
+            "datatype": "uint32",
+            "default": 0,
+            "description": "Supported Version of VSS - Patch version.",
+            "type": "attribute"
+          }
+        },
+        "description": "Supported Version of VSS.",
+        "type": "branch"
+      },
+      "Width": {
+        "datatype": "uint16",
+        "default": 0,
+        "deprecation": "v4.1 replaced with WidthExcludingMirrors and WidthIncludingMirrors",
+        "description": "Overall vehicle width.",
+        "type": "attribute",
+        "unit": "mm"
+      },
+      "WidthExcludingMirrors": {
+        "datatype": "uint16",
+        "default": 0,
+        "description": "Overall vehicle width excluding mirrors, as defined by SAE J1100-2009 W103.",
+        "type": "attribute",
+        "unit": "mm"
+      },
+      "WidthFoldedMirrors": {
+        "datatype": "uint16",
+        "description": "Overall vehicle width with mirrors folded, as defined by SAE J1100-2009 W145.",
+        "type": "attribute",
+        "unit": "mm"
+      },
+      "WidthIncludingMirrors": {
+        "datatype": "uint16",
+        "description": "Overall vehicle width including mirrors, as defined by SAE J1100-2009 W144.",
+        "type": "attribute",
+        "unit": "mm"
+      }
+    },
+    "description": "High-level vehicle data.",
+    "type": "branch"
+  }
+}


### PR DESCRIPTION
Fixes #30

I used VSS 4.2 as basis for testing, so I added that as well to our example collection. See end of 4.2 *.vspec file to find added testcases.

How to test:

Start Databroker with 4.2 (could be std 4.2)

`erik@debian6:~/kuksa-databroker$ cargo run --bin databroker -- --metadata ~/kuksa-can-provider/mapping/vss_4.2/vss_dbc.json`

Run dbcfeeder

`./dbcfeeder.py`

Use kuksa-client to test results.

```
Test Client> getValue Vehicle.Cabin.Infotainment.HMI.SpeedUnit
{
    "path": "Vehicle.Cabin.Infotainment.HMI.SpeedUnit",
    "value": {
        "value": "KILOMETERS_PER_HOUR",
        "timestamp": "2024-09-20T10:25:27.978556+00:00"
    }
}

Test Client> getValue Vehicle.Cabin.Infotainment.Media.Played.Album
{
    "path": "Vehicle.Cabin.Infotainment.Media.Played.Album",
    "value": {
        "value": "DI_SPEED_KPH",
        "timestamp": "2024-09-20T10:25:50.193728+00:00"
    }
}

Test Client> getValue Vehicle.Cabin.Infotainment.Media.Volume
{
    "path": "Vehicle.Cabin.Infotainment.Media.Volume",
    "value": {
        "value": 1,
        "timestamp": "2024-09-20T10:25:55.723813+00:00"
    }
}

```